### PR TITLE
Add command to add MPL Core Assets to Collections

### DIFF
--- a/src/commands/core/collection/add.ts
+++ b/src/commands/core/collection/add.ts
@@ -12,12 +12,12 @@ export default class CollectionAdd extends TransactionCommand<typeof CollectionA
   static override description = 'Add an existing MPL Core Asset to a Collection'
 
   static override examples = [
-    '<%= config.bin %> <%= command.id %> <collectionId> <assetId>',
+    '<%= config.bin %> <%= command.id %> <collection> <asset>',
   ]
 
   static override args = {
-    collectionId: Args.string({ description: 'Collection to add the asset to', required: true }),
-    assetId: Args.string({ description: 'Asset to add to the collection', required: true }),
+    collection: Args.string({ description: 'Collection to add the asset to', required: true }),
+    asset: Args.string({ description: 'Asset to add to the collection', required: true }),
   }
 
   public async run(): Promise<unknown> {
@@ -27,12 +27,12 @@ export default class CollectionAdd extends TransactionCommand<typeof CollectionA
     const spinner = ora('Fetching asset and collection...').start()
 
     try {
-      const asset = await fetchAsset(umi, publicKey(args.assetId))
-      const collection = await fetchCollection(umi, publicKey(args.collectionId))
+      const asset = await fetchAsset(umi, publicKey(args.asset))
+      const collection = await fetchCollection(umi, publicKey(args.collection))
 
       if (asset.updateAuthority.type === 'Collection') {
         spinner.fail('Asset is already in a collection')
-        this.error(`Asset ${args.assetId} already belongs to collection ${asset.updateAuthority.address}`)
+        this.error(`Asset ${args.asset} already belongs to collection ${asset.updateAuthority.address}`)
       }
 
       spinner.text = 'Adding asset to collection...'
@@ -49,15 +49,15 @@ export default class CollectionAdd extends TransactionCommand<typeof CollectionA
 
       spinner.succeed(`Asset added to collection`)
       this.logSuccess(`--------------------------------
-  Asset:      ${args.assetId}
-  Collection: ${args.collectionId}
+  Asset:      ${args.asset}
+  Collection: ${args.collection}
   Signature:  ${signature}
   Explorer:   ${explorerUrl}
 --------------------------------`)
 
       return {
-        asset: args.assetId,
-        collection: args.collectionId,
+        asset: args.asset,
+        collection: args.collection,
         signature,
         explorer: explorerUrl,
       }

--- a/src/commands/core/collection/add.ts
+++ b/src/commands/core/collection/add.ts
@@ -1,0 +1,70 @@
+import { baseUpdateAuthority, fetchAsset, fetchCollection, update } from '@metaplex-foundation/mpl-core'
+import { publicKey } from '@metaplex-foundation/umi'
+import { Args } from '@oclif/core'
+import ora from 'ora'
+
+import { generateExplorerUrl } from '../../../explorers.js'
+import { TransactionCommand } from '../../../TransactionCommand.js'
+import umiSendAndConfirmTransaction from '../../../lib/umi/sendAndConfirm.js'
+import { txSignatureToString } from '../../../lib/util.js'
+
+export default class CollectionAdd extends TransactionCommand<typeof CollectionAdd> {
+  static override description = 'Add an existing MPL Core Asset to a Collection'
+
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> <collectionId> <assetId>',
+  ]
+
+  static override args = {
+    collectionId: Args.string({ description: 'Collection to add the asset to', required: true }),
+    assetId: Args.string({ description: 'Asset to add to the collection', required: true }),
+  }
+
+  public async run(): Promise<unknown> {
+    const { args } = await this.parse(CollectionAdd)
+    const { umi, explorer, chain } = this.context
+
+    const spinner = ora('Fetching asset and collection...').start()
+
+    try {
+      const asset = await fetchAsset(umi, publicKey(args.assetId))
+      const collection = await fetchCollection(umi, publicKey(args.collectionId))
+
+      if (asset.updateAuthority.type === 'Collection') {
+        spinner.fail('Asset is already in a collection')
+        this.error(`Asset ${args.assetId} already belongs to collection ${asset.updateAuthority.address}`)
+      }
+
+      spinner.text = 'Adding asset to collection...'
+
+      const txBuilder = update(umi, {
+        asset,
+        newUpdateAuthority: baseUpdateAuthority('Collection', [collection.publicKey]),
+        newCollection: collection.publicKey,
+      })
+
+      const result = await umiSendAndConfirmTransaction(umi, txBuilder)
+      const signature = txSignatureToString(result.transaction.signature as Uint8Array)
+      const explorerUrl = generateExplorerUrl(explorer, chain, signature, 'transaction')
+
+      spinner.succeed(`Asset added to collection`)
+      this.logSuccess(`--------------------------------
+  Asset:      ${args.assetId}
+  Collection: ${args.collectionId}
+  Signature:  ${signature}
+  Explorer:   ${explorerUrl}
+--------------------------------`)
+
+      return {
+        asset: args.assetId,
+        collection: args.collectionId,
+        signature,
+        explorer: explorerUrl,
+      }
+    } catch (error) {
+      if (!spinner.isSpinning) throw error
+      spinner.fail('Failed to add asset to collection')
+      throw error
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds a new CLI command that allows users to add existing MPL Core Assets to Collections. The command updates an asset's update authority to point to a collection, effectively associating the asset with that collection.

## Key Changes
- Added `CollectionAdd` command class in `src/commands/core/collection/add.ts`
- Implements asset-to-collection association by updating the asset's update authority
- Accepts two required arguments: `collectionId` and `assetId`
- Includes validation to prevent adding assets that already belong to a collection
- Provides user feedback via spinner UI and formatted output with transaction signature and explorer link

## Implementation Details
- Fetches both the asset and collection from the blockchain before performing the update
- Uses the `update` function from `@metaplex-foundation/mpl-core` to modify the asset's update authority
- Sets the new update authority to a Collection type with the target collection's public key
- Returns transaction details including signature and explorer URL for verification
- Includes proper error handling with user-friendly error messages

https://claude.ai/code/session_01QjTrbKjMEQZoKDSzdmM7vV