### PR TITLE
Add bonding curve swap, bucket fetch, and registration flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@ledgerhq/hw-transport": "6.31.4",
     "@ledgerhq/hw-transport-node-hid-singleton": "6.31.5",
     "@metaplex-foundation/digital-asset-standard-api": "^2.0.0",
-    "@metaplex-foundation/genesis": "^0.32.1",
+    "@metaplex-foundation/genesis": "^0.34.0",
     "@metaplex-foundation/mpl-agent-registry": "^0.2.5",
     "@metaplex-foundation/mpl-bubblegum": "^5.0.2",
     "@metaplex-foundation/mpl-core": "^1.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@metaplex-foundation/umi@1.5.1)
       '@metaplex-foundation/genesis':
-        specifier: ^0.32.1
-        version: 0.32.1(@metaplex-foundation/umi@1.5.1)
+        specifier: ^0.34.0
+        version: 0.34.0(@metaplex-foundation/umi@1.5.1)
       '@metaplex-foundation/mpl-agent-registry':
         specifier: ^0.2.5
         version: 0.2.5(@metaplex-foundation/umi@1.5.1)(@noble/hashes@1.8.0)
@@ -909,8 +909,8 @@ packages:
     peerDependencies:
       '@metaplex-foundation/umi': '>= 0.8.2 <= 1'
 
-  '@metaplex-foundation/genesis@0.32.1':
-    resolution: {integrity: sha512-UwXFuLH7+d7N3DEjCCGOTrQ2I4JG969LJc3GtVa5kgS+pdO3wSvYnlTyq40nvF9wEBakTKG3s5Qzy7AKpk8Buw==}
+  '@metaplex-foundation/genesis@0.34.0':
+    resolution: {integrity: sha512-7ZbOFl6wi5e/fn5x1xQqNltFJejK3ndTQYEe38APwewh/Xf+Am4g5xt7mnBsts2DvZabm/R7nS8cFYbszmWaog==}
     peerDependencies:
       '@metaplex-foundation/umi': ^1.4.1
 
@@ -6105,7 +6105,7 @@ snapshots:
     dependencies:
       '@metaplex-foundation/umi': 1.5.1
 
-  '@metaplex-foundation/genesis@0.32.1(@metaplex-foundation/umi@1.5.1)':
+  '@metaplex-foundation/genesis@0.34.0(@metaplex-foundation/umi@1.5.1)':
     dependencies:
       '@metaplex-foundation/mpl-token-metadata': 3.4.0(@metaplex-foundation/umi@1.5.1)
       '@metaplex-foundation/mpl-toolbox': 0.10.0(@metaplex-foundation/umi@1.5.1)
@@ -7478,7 +7478,7 @@ snapshots:
 
   axios@1.8.4:
     dependencies:
-      follow-redirects: 1.15.9(debug@4.4.0)
+      follow-redirects: 1.15.9(debug@4.3.4)
       form-data: 4.0.2
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -8132,8 +8132,8 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.8.3)
       eslint-config-xo-space: 0.35.0(eslint@8.57.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-mocha: 10.5.0(eslint@8.57.1)
       eslint-plugin-n: 15.7.0(eslint@8.57.1)
       eslint-plugin-perfectionist: 2.11.0(eslint@8.57.1)(typescript@5.8.3)
@@ -8179,7 +8179,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0(supports-color@8.1.1)
@@ -8190,18 +8190,18 @@ snapshots:
       tinyglobby: 0.2.13
       unrs-resolver: 1.6.4
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8211,7 +8211,7 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -8222,7 +8222,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/src/commands/genesis/bucket/fetch.ts
+++ b/src/commands/genesis/bucket/fetch.ts
@@ -1,20 +1,20 @@
 import {
-  safeFetchGenesisAccountV2,
-  findLaunchPoolBucketV2Pda,
-  safeFetchLaunchPoolBucketV2,
-  findPresaleBucketV2Pda,
-  safeFetchPresaleBucketV2,
-  findUnlockedBucketV2Pda,
-  safeFetchUnlockedBucketV2,
   findBondingCurveBucketV2Pda,
-  safeFetchBondingCurveBucketV2,
+  findLaunchPoolBucketV2Pda,
+  findPresaleBucketV2Pda,
+  findUnlockedBucketV2Pda,
   getCurrentPrice,
-  getCurrentPriceQuotePerBase,
   getCurrentPriceComponents,
-  isFirstBuyPending,
-  isSwappable,
-  isSoldOut,
+  getCurrentPriceQuotePerBase,
   getFillPercentage,
+  isFirstBuyPending,
+  isSoldOut,
+  isSwappable,
+  safeFetchBondingCurveBucketV2,
+  safeFetchGenesisAccountV2,
+  safeFetchLaunchPoolBucketV2,
+  safeFetchPresaleBucketV2,
+  safeFetchUnlockedBucketV2,
 } from '@metaplex-foundation/genesis'
 import { publicKey } from '@metaplex-foundation/umi'
 import { Args, Flags } from '@oclif/core'
@@ -30,10 +30,18 @@ function formatCondition(condition: { __kind: string; time?: bigint }): string {
     if (timestamp === 0) return 'Not set'
     return new Date(timestamp * 1000).toISOString()
   }
+
   return `${condition.__kind}`
 }
 
 export default class BucketFetch extends BaseCommand<typeof BucketFetch> {
+  static override args = {
+    genesis: Args.string({
+      description: 'The Genesis account address',
+      required: true,
+    }),
+  }
+
   static override description = `Fetch a Genesis bucket by genesis address and bucket index.
 
 This command retrieves and displays information about a bucket in a Genesis account.
@@ -49,20 +57,11 @@ all known types at the given index.`
     '$ mplx genesis bucket fetch GenesisAddress... --type bonding-curve',
   ]
 
-  static override usage = 'genesis bucket fetch [GENESIS] [FLAGS]'
-
-  static override args = {
-    genesis: Args.string({
-      description: 'The Genesis account address',
-      required: true,
-    }),
-  }
-
   static override flags = {
     bucketIndex: Flags.integer({
       char: 'b',
-      description: 'Index of the bucket to fetch',
       default: 0,
+      description: 'Index of the bucket to fetch',
     }),
     type: Flags.option({
       char: 't',
@@ -71,6 +70,8 @@ all known types at the given index.`
       required: false,
     })(),
   }
+
+  static override usage = 'genesis bucket fetch [GENESIS] [FLAGS]'
 
   public async run(): Promise<unknown> {
     const { args, flags } = await this.parse(BucketFetch)
@@ -94,13 +95,18 @@ all known types at the given index.`
         // Explicit type specified
         if (flags.type === 'presale') {
           return await this.fetchPresaleBucket(genesisAddress, flags.bucketIndex, spinner)
-        } else if (flags.type === 'unlocked') {
-          return await this.fetchUnlockedBucket(genesisAddress, flags.bucketIndex, spinner)
-        } else if (flags.type === 'bonding-curve') {
-          return await this.fetchBondingCurveBucket(genesisAddress, flags.bucketIndex, spinner)
-        } else {
-          return await this.fetchLaunchPoolBucket(genesisAddress, flags.bucketIndex, spinner)
         }
+
+ if (flags.type === 'unlocked') {
+          return await this.fetchUnlockedBucket(genesisAddress, flags.bucketIndex, spinner)
+        }
+
+ if (flags.type === 'bonding-curve') {
+          return await this.fetchBondingCurveBucket(genesisAddress, flags.bucketIndex, spinner)
+        }
+ 
+          return await this.fetchLaunchPoolBucket(genesisAddress, flags.bucketIndex, spinner)
+        
       }
 
       // Auto-detect: try all bucket types at this index
@@ -116,17 +122,17 @@ all known types at the given index.`
   private async fetchAutoDetect(genesisAddress: ReturnType<typeof publicKey>, bucketIndex: number, spinner: ReturnType<typeof ora>): Promise<unknown> {
     // Probe all bucket types at this index in parallel
     const [bc, lp, pre, ul] = await Promise.all([
-      safeFetchBondingCurveBucketV2(this.context.umi, findBondingCurveBucketV2Pda(this.context.umi, { genesisAccount: genesisAddress, bucketIndex })[0]),
-      safeFetchLaunchPoolBucketV2(this.context.umi, findLaunchPoolBucketV2Pda(this.context.umi, { genesisAccount: genesisAddress, bucketIndex })[0]),
-      safeFetchPresaleBucketV2(this.context.umi, findPresaleBucketV2Pda(this.context.umi, { genesisAccount: genesisAddress, bucketIndex })[0]),
-      safeFetchUnlockedBucketV2(this.context.umi, findUnlockedBucketV2Pda(this.context.umi, { genesisAccount: genesisAddress, bucketIndex })[0]),
+      safeFetchBondingCurveBucketV2(this.context.umi, findBondingCurveBucketV2Pda(this.context.umi, { bucketIndex, genesisAccount: genesisAddress })[0]),
+      safeFetchLaunchPoolBucketV2(this.context.umi, findLaunchPoolBucketV2Pda(this.context.umi, { bucketIndex, genesisAccount: genesisAddress })[0]),
+      safeFetchPresaleBucketV2(this.context.umi, findPresaleBucketV2Pda(this.context.umi, { bucketIndex, genesisAccount: genesisAddress })[0]),
+      safeFetchUnlockedBucketV2(this.context.umi, findUnlockedBucketV2Pda(this.context.umi, { bucketIndex, genesisAccount: genesisAddress })[0]),
     ])
 
-    const found: { type: string; fn: () => Promise<unknown> }[] = []
-    if (bc) found.push({ type: 'bonding-curve', fn: () => this.fetchBondingCurveBucket(genesisAddress, bucketIndex, spinner) })
-    if (lp) found.push({ type: 'launch-pool', fn: () => this.fetchLaunchPoolBucket(genesisAddress, bucketIndex, spinner) })
-    if (pre) found.push({ type: 'presale', fn: () => this.fetchPresaleBucket(genesisAddress, bucketIndex, spinner) })
-    if (ul) found.push({ type: 'unlocked', fn: () => this.fetchUnlockedBucket(genesisAddress, bucketIndex, spinner) })
+    const found: { fn: () => Promise<unknown>; type: string }[] = []
+    if (bc) found.push({ fn: () => this.fetchBondingCurveBucket(genesisAddress, bucketIndex, spinner), type: 'bonding-curve' })
+    if (lp) found.push({ fn: () => this.fetchLaunchPoolBucket(genesisAddress, bucketIndex, spinner), type: 'launch-pool' })
+    if (pre) found.push({ fn: () => this.fetchPresaleBucket(genesisAddress, bucketIndex, spinner), type: 'presale' })
+    if (ul) found.push({ fn: () => this.fetchUnlockedBucket(genesisAddress, bucketIndex, spinner), type: 'unlocked' })
 
     if (found.length === 0) {
       spinner.fail('Bucket not found')
@@ -139,154 +145,19 @@ all known types at the given index.`
 
     // Multiple bucket types at the same index — show all
     spinner.succeed(`Found ${found.length} buckets at index ${bucketIndex}`)
-    const results: unknown[] = []
-    for (const { fn } of found) {
-      results.push(await fn())
+    const results: unknown[] = await Promise.all(found.map(async ({ fn }) => {
+      const result = await fn()
       this.log('')
-    }
+      return result
+    }))
+
     return results
-  }
-
-  private async fetchLaunchPoolBucket(genesisAddress: ReturnType<typeof publicKey>, bucketIndex: number, spinner: ReturnType<typeof ora>): Promise<unknown> {
-    const [bucketPda] = findLaunchPoolBucketV2Pda(this.context.umi, {
-      genesisAccount: genesisAddress,
-      bucketIndex,
-    })
-
-    const bucket = await safeFetchLaunchPoolBucketV2(this.context.umi, bucketPda)
-
-    if (!bucket) {
-      spinner.fail('Bucket not found')
-      this.error(`Launch pool bucket not found at index ${bucketIndex}. It may be a different bucket type or not exist.`)
-    }
-
-    spinner.succeed('Bucket fetched successfully!')
-
-    this.log('')
-    this.logSuccess(`Launch Pool Bucket`)
-    this.log('')
-    this.log('Bucket Details:')
-    this.log(`  Address: ${bucketPda}`)
-    this.log(`  Type: ${KEY_TYPES[bucket.key] || 'Unknown'}`)
-    this.log(`  Genesis Account: ${bucket.bucket.genesis}`)
-    this.log(`  Bucket Index: ${bucket.bucket.bucketIndex}`)
-    this.log('')
-    this.log('Allocation:')
-    this.log(`  Base Token Allocation: ${bucket.bucket.baseTokenAllocation.toString()}`)
-    this.log(`  Base Token Balance: ${bucket.bucket.baseTokenBalance.toString()}`)
-    this.log('')
-    this.log('Deposits:')
-    this.log(`  Deposit Count: ${bucket.depositCount.toString()}`)
-    this.log(`  Total Quote Tokens Deposited: ${bucket.quoteTokenDepositTotal.toString()}`)
-    this.log(`  Weighted Quote Token Total: ${bucket.weightedQuoteTokenTotal.toString()}`)
-    this.log('')
-    this.log('Claims:')
-    this.log(`  Claim Count: ${bucket.claimCount.toString()}`)
-    this.log('')
-    this.log('Schedule:')
-    this.log(`  Deposit Start: ${formatCondition(bucket.depositStartCondition)}`)
-    this.log(`  Deposit End: ${formatCondition(bucket.depositEndCondition)}`)
-    this.log(`  Claim Start: ${formatCondition(bucket.claimStartCondition)}`)
-    this.log(`  Claim End: ${formatCondition(bucket.claimEndCondition)}`)
-    this.log('')
-    this.log('Fees:')
-    this.log(`  Deposit Fee: ${bucket.depositFee.toString()}`)
-    this.log(`  Withdraw Fee: ${bucket.withdrawFee.toString()}`)
-    this.log(`  Claim Fee: ${bucket.claimFee.toString()}`)
-    this.log('')
-    this.log('View on Explorer:')
-    this.log(
-      generateExplorerUrl(
-        this.context.explorer,
-        this.context.chain,
-        bucketPda,
-        'account'
-      )
-    )
-
-    return {
-      type: 'launch-pool',
-      address: bucketPda.toString(),
-      genesisAccount: bucket.bucket.genesis.toString(),
-      bucketIndex: bucket.bucket.bucketIndex,
-      baseTokenAllocation: bucket.bucket.baseTokenAllocation.toString(),
-      baseTokenBalance: bucket.bucket.baseTokenBalance.toString(),
-      explorer: generateExplorerUrl(this.context.explorer, this.context.chain, bucketPda, 'account'),
-    }
-  }
-
-  private async fetchPresaleBucket(genesisAddress: ReturnType<typeof publicKey>, bucketIndex: number, spinner: ReturnType<typeof ora>): Promise<unknown> {
-    const [bucketPda] = findPresaleBucketV2Pda(this.context.umi, {
-      genesisAccount: genesisAddress,
-      bucketIndex,
-    })
-
-    const bucket = await safeFetchPresaleBucketV2(this.context.umi, bucketPda)
-
-    if (!bucket) {
-      spinner.fail('Bucket not found')
-      this.error(`Presale bucket not found at index ${bucketIndex}. It may be a different bucket type or not exist.`)
-    }
-
-    spinner.succeed('Bucket fetched successfully!')
-
-    this.log('')
-    this.logSuccess(`Presale Bucket`)
-    this.log('')
-    this.log('Bucket Details:')
-    this.log(`  Address: ${bucketPda}`)
-    this.log(`  Type: ${KEY_TYPES[bucket.key] || 'Unknown'}`)
-    this.log(`  Genesis Account: ${bucket.bucket.genesis}`)
-    this.log(`  Bucket Index: ${bucket.bucket.bucketIndex}`)
-    this.log('')
-    this.log('Allocation:')
-    this.log(`  Base Token Allocation: ${bucket.bucket.baseTokenAllocation.toString()}`)
-    this.log(`  Base Token Balance: ${bucket.bucket.baseTokenBalance.toString()}`)
-    this.log(`  Quote Token Cap: ${bucket.allocationQuoteTokenCap.toString()}`)
-    this.log('')
-    this.log('Deposits:')
-    this.log(`  Deposit Count: ${bucket.depositCount.toString()}`)
-    this.log(`  Total Quote Tokens Deposited: ${bucket.quoteTokenDepositTotal.toString()}`)
-    this.log('')
-    this.log('Claims:')
-    this.log(`  Claim Count: ${bucket.claimCount.toString()}`)
-    this.log('')
-    this.log('Schedule:')
-    this.log(`  Deposit Start: ${formatCondition(bucket.depositStartCondition)}`)
-    this.log(`  Deposit End: ${formatCondition(bucket.depositEndCondition)}`)
-    this.log(`  Claim Start: ${formatCondition(bucket.claimStartCondition)}`)
-    this.log(`  Claim End: ${formatCondition(bucket.claimEndCondition)}`)
-    this.log('')
-    this.log('Fees:')
-    this.log(`  Deposit Fee: ${bucket.depositFee.toString()}`)
-    this.log(`  Claim Fee: ${bucket.claimFee.toString()}`)
-    this.log('')
-    this.log('View on Explorer:')
-    this.log(
-      generateExplorerUrl(
-        this.context.explorer,
-        this.context.chain,
-        bucketPda,
-        'account'
-      )
-    )
-
-    return {
-      type: 'presale',
-      address: bucketPda.toString(),
-      genesisAccount: bucket.bucket.genesis.toString(),
-      bucketIndex: bucket.bucket.bucketIndex,
-      baseTokenAllocation: bucket.bucket.baseTokenAllocation.toString(),
-      baseTokenBalance: bucket.bucket.baseTokenBalance.toString(),
-      allocationQuoteTokenCap: bucket.allocationQuoteTokenCap.toString(),
-      explorer: generateExplorerUrl(this.context.explorer, this.context.chain, bucketPda, 'account'),
-    }
   }
 
   private async fetchBondingCurveBucket(genesisAddress: ReturnType<typeof publicKey>, bucketIndex: number, spinner: ReturnType<typeof ora>): Promise<unknown> {
     const [bucketPda] = findBondingCurveBucketV2Pda(this.context.umi, {
-      genesisAccount: genesisAddress,
       bucketIndex,
+      genesisAccount: genesisAddress,
     })
 
     const bucket = await safeFetchBondingCurveBucketV2(this.context.umi, bucketPda)
@@ -357,33 +228,169 @@ all known types at the given index.`
     )
 
     return {
-      type: 'bonding-curve',
       address: bucketPda.toString(),
-      genesisAccount: bucket.bucket.genesis.toString(),
-      bucketIndex: bucket.bucket.bucketIndex,
+      baseReserves: baseReserves.toString(),
       baseTokenAllocation: bucket.bucket.baseTokenAllocation.toString(),
       baseTokenBalance: bucket.bucket.baseTokenBalance.toString(),
-      quoteTokenDepositTotal: bucket.quoteTokenDepositTotal.toString(),
-      currentPrice: price.toString(),
-      currentPriceQuotePerBase: priceQuotePerBase.toString(),
-      baseReserves: baseReserves.toString(),
-      quoteReserves: quoteReserves.toString(),
-      virtualSol: bucket.constantProductParams.virtualSol.toString(),
-      virtualTokens: bucket.constantProductParams.virtualTokens.toString(),
-      firstBuyPending,
-      swappable,
-      soldOut,
-      fillPercentage: fillPct,
+      bucketIndex: bucket.bucket.bucketIndex,
       creatorFeeAccrued: bucket.creatorFeeAccrued.toString(),
       creatorFeeClaimed: bucket.creatorFeeClaimed.toString(),
+      currentPrice: price.toString(),
+      currentPriceQuotePerBase: priceQuotePerBase.toString(),
       explorer: generateExplorerUrl(this.context.explorer, this.context.chain, bucketPda, 'account'),
+      fillPercentage: fillPct,
+      firstBuyPending,
+      genesisAccount: bucket.bucket.genesis.toString(),
+      quoteReserves: quoteReserves.toString(),
+      quoteTokenDepositTotal: bucket.quoteTokenDepositTotal.toString(),
+      soldOut,
+      swappable,
+      type: 'bonding-curve',
+      virtualSol: bucket.constantProductParams.virtualSol.toString(),
+      virtualTokens: bucket.constantProductParams.virtualTokens.toString(),
+    }
+  }
+
+  private async fetchLaunchPoolBucket(genesisAddress: ReturnType<typeof publicKey>, bucketIndex: number, spinner: ReturnType<typeof ora>): Promise<unknown> {
+    const [bucketPda] = findLaunchPoolBucketV2Pda(this.context.umi, {
+      bucketIndex,
+      genesisAccount: genesisAddress,
+    })
+
+    const bucket = await safeFetchLaunchPoolBucketV2(this.context.umi, bucketPda)
+
+    if (!bucket) {
+      spinner.fail('Bucket not found')
+      this.error(`Launch pool bucket not found at index ${bucketIndex}. It may be a different bucket type or not exist.`)
+    }
+
+    spinner.succeed('Bucket fetched successfully!')
+
+    this.log('')
+    this.logSuccess(`Launch Pool Bucket`)
+    this.log('')
+    this.log('Bucket Details:')
+    this.log(`  Address: ${bucketPda}`)
+    this.log(`  Type: ${KEY_TYPES[bucket.key] || 'Unknown'}`)
+    this.log(`  Genesis Account: ${bucket.bucket.genesis}`)
+    this.log(`  Bucket Index: ${bucket.bucket.bucketIndex}`)
+    this.log('')
+    this.log('Allocation:')
+    this.log(`  Base Token Allocation: ${bucket.bucket.baseTokenAllocation.toString()}`)
+    this.log(`  Base Token Balance: ${bucket.bucket.baseTokenBalance.toString()}`)
+    this.log('')
+    this.log('Deposits:')
+    this.log(`  Deposit Count: ${bucket.depositCount.toString()}`)
+    this.log(`  Total Quote Tokens Deposited: ${bucket.quoteTokenDepositTotal.toString()}`)
+    this.log(`  Weighted Quote Token Total: ${bucket.weightedQuoteTokenTotal.toString()}`)
+    this.log('')
+    this.log('Claims:')
+    this.log(`  Claim Count: ${bucket.claimCount.toString()}`)
+    this.log('')
+    this.log('Schedule:')
+    this.log(`  Deposit Start: ${formatCondition(bucket.depositStartCondition)}`)
+    this.log(`  Deposit End: ${formatCondition(bucket.depositEndCondition)}`)
+    this.log(`  Claim Start: ${formatCondition(bucket.claimStartCondition)}`)
+    this.log(`  Claim End: ${formatCondition(bucket.claimEndCondition)}`)
+    this.log('')
+    this.log('Fees:')
+    this.log(`  Deposit Fee: ${bucket.depositFee.toString()}`)
+    this.log(`  Withdraw Fee: ${bucket.withdrawFee.toString()}`)
+    this.log(`  Claim Fee: ${bucket.claimFee.toString()}`)
+    this.log('')
+    this.log('View on Explorer:')
+    this.log(
+      generateExplorerUrl(
+        this.context.explorer,
+        this.context.chain,
+        bucketPda,
+        'account'
+      )
+    )
+
+    return {
+      address: bucketPda.toString(),
+      baseTokenAllocation: bucket.bucket.baseTokenAllocation.toString(),
+      baseTokenBalance: bucket.bucket.baseTokenBalance.toString(),
+      bucketIndex: bucket.bucket.bucketIndex,
+      explorer: generateExplorerUrl(this.context.explorer, this.context.chain, bucketPda, 'account'),
+      genesisAccount: bucket.bucket.genesis.toString(),
+      type: 'launch-pool',
+    }
+  }
+
+  private async fetchPresaleBucket(genesisAddress: ReturnType<typeof publicKey>, bucketIndex: number, spinner: ReturnType<typeof ora>): Promise<unknown> {
+    const [bucketPda] = findPresaleBucketV2Pda(this.context.umi, {
+      bucketIndex,
+      genesisAccount: genesisAddress,
+    })
+
+    const bucket = await safeFetchPresaleBucketV2(this.context.umi, bucketPda)
+
+    if (!bucket) {
+      spinner.fail('Bucket not found')
+      this.error(`Presale bucket not found at index ${bucketIndex}. It may be a different bucket type or not exist.`)
+    }
+
+    spinner.succeed('Bucket fetched successfully!')
+
+    this.log('')
+    this.logSuccess(`Presale Bucket`)
+    this.log('')
+    this.log('Bucket Details:')
+    this.log(`  Address: ${bucketPda}`)
+    this.log(`  Type: ${KEY_TYPES[bucket.key] || 'Unknown'}`)
+    this.log(`  Genesis Account: ${bucket.bucket.genesis}`)
+    this.log(`  Bucket Index: ${bucket.bucket.bucketIndex}`)
+    this.log('')
+    this.log('Allocation:')
+    this.log(`  Base Token Allocation: ${bucket.bucket.baseTokenAllocation.toString()}`)
+    this.log(`  Base Token Balance: ${bucket.bucket.baseTokenBalance.toString()}`)
+    this.log(`  Quote Token Cap: ${bucket.allocationQuoteTokenCap.toString()}`)
+    this.log('')
+    this.log('Deposits:')
+    this.log(`  Deposit Count: ${bucket.depositCount.toString()}`)
+    this.log(`  Total Quote Tokens Deposited: ${bucket.quoteTokenDepositTotal.toString()}`)
+    this.log('')
+    this.log('Claims:')
+    this.log(`  Claim Count: ${bucket.claimCount.toString()}`)
+    this.log('')
+    this.log('Schedule:')
+    this.log(`  Deposit Start: ${formatCondition(bucket.depositStartCondition)}`)
+    this.log(`  Deposit End: ${formatCondition(bucket.depositEndCondition)}`)
+    this.log(`  Claim Start: ${formatCondition(bucket.claimStartCondition)}`)
+    this.log(`  Claim End: ${formatCondition(bucket.claimEndCondition)}`)
+    this.log('')
+    this.log('Fees:')
+    this.log(`  Deposit Fee: ${bucket.depositFee.toString()}`)
+    this.log(`  Claim Fee: ${bucket.claimFee.toString()}`)
+    this.log('')
+    this.log('View on Explorer:')
+    this.log(
+      generateExplorerUrl(
+        this.context.explorer,
+        this.context.chain,
+        bucketPda,
+        'account'
+      )
+    )
+
+    return {
+      address: bucketPda.toString(),
+      allocationQuoteTokenCap: bucket.allocationQuoteTokenCap.toString(),
+      baseTokenAllocation: bucket.bucket.baseTokenAllocation.toString(),
+      baseTokenBalance: bucket.bucket.baseTokenBalance.toString(),
+      bucketIndex: bucket.bucket.bucketIndex,
+      explorer: generateExplorerUrl(this.context.explorer, this.context.chain, bucketPda, 'account'),
+      genesisAccount: bucket.bucket.genesis.toString(),
+      type: 'presale',
     }
   }
 
   private async fetchUnlockedBucket(genesisAddress: ReturnType<typeof publicKey>, bucketIndex: number, spinner: ReturnType<typeof ora>): Promise<unknown> {
     const [bucketPda] = findUnlockedBucketV2Pda(this.context.umi, {
-      genesisAccount: genesisAddress,
       bucketIndex,
+      genesisAccount: genesisAddress,
     })
 
     const bucket = await safeFetchUnlockedBucketV2(this.context.umi, bucketPda)
@@ -427,15 +434,15 @@ all known types at the given index.`
     )
 
     return {
-      type: 'unlocked',
       address: bucketPda.toString(),
-      genesisAccount: bucket.bucket.genesis.toString(),
-      bucketIndex: bucket.bucket.bucketIndex,
       baseTokenAllocation: bucket.bucket.baseTokenAllocation.toString(),
       baseTokenBalance: bucket.bucket.baseTokenBalance.toString(),
-      recipient: bucket.recipient.toString(),
+      bucketIndex: bucket.bucket.bucketIndex,
       claimed: bucket.claimed,
       explorer: generateExplorerUrl(this.context.explorer, this.context.chain, bucketPda, 'account'),
+      genesisAccount: bucket.bucket.genesis.toString(),
+      recipient: bucket.recipient.toString(),
+      type: 'unlocked',
     }
   }
 }

--- a/src/commands/genesis/bucket/fetch.ts
+++ b/src/commands/genesis/bucket/fetch.ts
@@ -37,13 +37,16 @@ export default class BucketFetch extends BaseCommand<typeof BucketFetch> {
   static override description = `Fetch a Genesis bucket by genesis address and bucket index.
 
 This command retrieves and displays information about a bucket in a Genesis account.
-Supports Launch Pool, Presale, Unlocked, and Bonding Curve bucket types.`
+Supports Launch Pool, Presale, Unlocked, and Bonding Curve bucket types.
+
+When --type is not specified, the command auto-detects the bucket type by trying
+all known types at the given index.`
 
   static override examples = [
-    '$ mplx genesis bucket fetch GenesisAddress... --bucketIndex 0',
-    '$ mplx genesis bucket fetch GenesisAddress... -b 1 --type presale',
-    '$ mplx genesis bucket fetch GenesisAddress... -b 2 --type unlocked',
-    '$ mplx genesis bucket fetch GenesisAddress... -b 0 --type bonding-curve',
+    '$ mplx genesis bucket fetch GenesisAddress...',
+    '$ mplx genesis bucket fetch GenesisAddress... -b 1',
+    '$ mplx genesis bucket fetch GenesisAddress... --type presale -b 0',
+    '$ mplx genesis bucket fetch GenesisAddress... --type bonding-curve',
   ]
 
   static override usage = 'genesis bucket fetch [GENESIS] [FLAGS]'
@@ -63,9 +66,9 @@ Supports Launch Pool, Presale, Unlocked, and Bonding Curve bucket types.`
     }),
     type: Flags.option({
       char: 't',
-      description: 'Type of bucket to fetch',
-      default: 'launch-pool',
+      description: 'Type of bucket to fetch (auto-detected if not specified)',
       options: ['launch-pool', 'presale', 'unlocked', 'bonding-curve'] as const,
+      required: false,
     })(),
   }
 
@@ -87,20 +90,61 @@ Supports Launch Pool, Presale, Unlocked, and Bonding Curve bucket types.`
 
       spinner.text = 'Fetching bucket details...'
 
-      if (flags.type === 'presale') {
-        return await this.fetchPresaleBucket(genesisAddress, flags.bucketIndex, spinner)
-      } else if (flags.type === 'unlocked') {
-        return await this.fetchUnlockedBucket(genesisAddress, flags.bucketIndex, spinner)
-      } else if (flags.type === 'bonding-curve') {
-        return await this.fetchBondingCurveBucket(genesisAddress, flags.bucketIndex, spinner)
-      } else {
-        return await this.fetchLaunchPoolBucket(genesisAddress, flags.bucketIndex, spinner)
+      if (flags.type) {
+        // Explicit type specified
+        if (flags.type === 'presale') {
+          return await this.fetchPresaleBucket(genesisAddress, flags.bucketIndex, spinner)
+        } else if (flags.type === 'unlocked') {
+          return await this.fetchUnlockedBucket(genesisAddress, flags.bucketIndex, spinner)
+        } else if (flags.type === 'bonding-curve') {
+          return await this.fetchBondingCurveBucket(genesisAddress, flags.bucketIndex, spinner)
+        } else {
+          return await this.fetchLaunchPoolBucket(genesisAddress, flags.bucketIndex, spinner)
+        }
       }
+
+      // Auto-detect: try all bucket types at this index
+      spinner.text = 'Detecting bucket type...'
+      return await this.fetchAutoDetect(genesisAddress, flags.bucketIndex, spinner)
 
     } catch (error) {
       spinner.fail('Failed to fetch bucket')
       throw error
     }
+  }
+
+  private async fetchAutoDetect(genesisAddress: ReturnType<typeof publicKey>, bucketIndex: number, spinner: ReturnType<typeof ora>): Promise<unknown> {
+    // Probe all bucket types at this index in parallel
+    const [bc, lp, pre, ul] = await Promise.all([
+      safeFetchBondingCurveBucketV2(this.context.umi, findBondingCurveBucketV2Pda(this.context.umi, { genesisAccount: genesisAddress, bucketIndex })[0]),
+      safeFetchLaunchPoolBucketV2(this.context.umi, findLaunchPoolBucketV2Pda(this.context.umi, { genesisAccount: genesisAddress, bucketIndex })[0]),
+      safeFetchPresaleBucketV2(this.context.umi, findPresaleBucketV2Pda(this.context.umi, { genesisAccount: genesisAddress, bucketIndex })[0]),
+      safeFetchUnlockedBucketV2(this.context.umi, findUnlockedBucketV2Pda(this.context.umi, { genesisAccount: genesisAddress, bucketIndex })[0]),
+    ])
+
+    const found: { type: string; fn: () => Promise<unknown> }[] = []
+    if (bc) found.push({ type: 'bonding-curve', fn: () => this.fetchBondingCurveBucket(genesisAddress, bucketIndex, spinner) })
+    if (lp) found.push({ type: 'launch-pool', fn: () => this.fetchLaunchPoolBucket(genesisAddress, bucketIndex, spinner) })
+    if (pre) found.push({ type: 'presale', fn: () => this.fetchPresaleBucket(genesisAddress, bucketIndex, spinner) })
+    if (ul) found.push({ type: 'unlocked', fn: () => this.fetchUnlockedBucket(genesisAddress, bucketIndex, spinner) })
+
+    if (found.length === 0) {
+      spinner.fail('Bucket not found')
+      this.error(`No bucket found at index ${bucketIndex}. Tried all bucket types (launch-pool, presale, unlocked, bonding-curve).`)
+    }
+
+    if (found.length === 1) {
+      return found[0].fn()
+    }
+
+    // Multiple bucket types at the same index — show all
+    spinner.succeed(`Found ${found.length} buckets at index ${bucketIndex}`)
+    const results: unknown[] = []
+    for (const { fn } of found) {
+      results.push(await fn())
+      this.log('')
+    }
+    return results
   }
 
   private async fetchLaunchPoolBucket(genesisAddress: ReturnType<typeof publicKey>, bucketIndex: number, spinner: ReturnType<typeof ora>): Promise<unknown> {

--- a/src/commands/genesis/bucket/fetch.ts
+++ b/src/commands/genesis/bucket/fetch.ts
@@ -6,6 +6,15 @@ import {
   safeFetchPresaleBucketV2,
   findUnlockedBucketV2Pda,
   safeFetchUnlockedBucketV2,
+  findBondingCurveBucketV2Pda,
+  safeFetchBondingCurveBucketV2,
+  getCurrentPrice,
+  getCurrentPriceQuotePerBase,
+  getCurrentPriceComponents,
+  isFirstBuyPending,
+  isSwappable,
+  isSoldOut,
+  getFillPercentage,
 } from '@metaplex-foundation/genesis'
 import { publicKey } from '@metaplex-foundation/umi'
 import { Args, Flags } from '@oclif/core'
@@ -28,12 +37,13 @@ export default class BucketFetch extends BaseCommand<typeof BucketFetch> {
   static override description = `Fetch a Genesis bucket by genesis address and bucket index.
 
 This command retrieves and displays information about a bucket in a Genesis account.
-Supports Launch Pool, Presale, and Unlocked bucket types.`
+Supports Launch Pool, Presale, Unlocked, and Bonding Curve bucket types.`
 
   static override examples = [
     '$ mplx genesis bucket fetch GenesisAddress... --bucketIndex 0',
     '$ mplx genesis bucket fetch GenesisAddress... -b 1 --type presale',
     '$ mplx genesis bucket fetch GenesisAddress... -b 2 --type unlocked',
+    '$ mplx genesis bucket fetch GenesisAddress... -b 0 --type bonding-curve',
   ]
 
   static override usage = 'genesis bucket fetch [GENESIS] [FLAGS]'
@@ -55,7 +65,7 @@ Supports Launch Pool, Presale, and Unlocked bucket types.`
       char: 't',
       description: 'Type of bucket to fetch',
       default: 'launch-pool',
-      options: ['launch-pool', 'presale', 'unlocked'] as const,
+      options: ['launch-pool', 'presale', 'unlocked', 'bonding-curve'] as const,
     })(),
   }
 
@@ -81,6 +91,8 @@ Supports Launch Pool, Presale, and Unlocked bucket types.`
         return await this.fetchPresaleBucket(genesisAddress, flags.bucketIndex, spinner)
       } else if (flags.type === 'unlocked') {
         return await this.fetchUnlockedBucket(genesisAddress, flags.bucketIndex, spinner)
+      } else if (flags.type === 'bonding-curve') {
+        return await this.fetchBondingCurveBucket(genesisAddress, flags.bucketIndex, spinner)
       } else {
         return await this.fetchLaunchPoolBucket(genesisAddress, flags.bucketIndex, spinner)
       }
@@ -223,6 +235,103 @@ Supports Launch Pool, Presale, and Unlocked bucket types.`
       baseTokenAllocation: bucket.bucket.baseTokenAllocation.toString(),
       baseTokenBalance: bucket.bucket.baseTokenBalance.toString(),
       allocationQuoteTokenCap: bucket.allocationQuoteTokenCap.toString(),
+      explorer: generateExplorerUrl(this.context.explorer, this.context.chain, bucketPda, 'account'),
+    }
+  }
+
+  private async fetchBondingCurveBucket(genesisAddress: ReturnType<typeof publicKey>, bucketIndex: number, spinner: ReturnType<typeof ora>): Promise<unknown> {
+    const [bucketPda] = findBondingCurveBucketV2Pda(this.context.umi, {
+      genesisAccount: genesisAddress,
+      bucketIndex,
+    })
+
+    const bucket = await safeFetchBondingCurveBucketV2(this.context.umi, bucketPda)
+
+    if (!bucket) {
+      spinner.fail('Bucket not found')
+      this.error(`Bonding curve bucket not found at index ${bucketIndex}. It may be a different bucket type or not exist.`)
+    }
+
+    spinner.succeed('Bucket fetched successfully!')
+
+    const price = getCurrentPrice(bucket)
+    const priceQuotePerBase = getCurrentPriceQuotePerBase(bucket)
+    const { baseReserves, quoteReserves } = getCurrentPriceComponents(bucket)
+    const firstBuyPending = isFirstBuyPending(bucket)
+    const swappable = isSwappable(bucket)
+    const soldOut = isSoldOut(bucket)
+    const fillPct = getFillPercentage(bucket)
+
+    this.log('')
+    this.logSuccess(`Bonding Curve Bucket`)
+    this.log('')
+    this.log('Bucket Details:')
+    this.log(`  Address: ${bucketPda}`)
+    this.log(`  Type: ${KEY_TYPES[bucket.key] || 'BondingCurveV2'}`)
+    this.log(`  Genesis Account: ${bucket.bucket.genesis}`)
+    this.log(`  Bucket Index: ${bucket.bucket.bucketIndex}`)
+    this.log('')
+    this.log('Allocation:')
+    this.log(`  Base Token Allocation: ${bucket.bucket.baseTokenAllocation.toString()}`)
+    this.log(`  Base Token Balance: ${bucket.bucket.baseTokenBalance.toString()}`)
+    this.log(`  Quote Token Deposit Total: ${bucket.quoteTokenDepositTotal.toString()}`)
+    this.log('')
+    this.log('Pricing:')
+    this.log(`  Current Price (tokens per quote): ${price.toString()}`)
+    this.log(`  Current Price (quote per token): ${priceQuotePerBase.toString()}`)
+    this.log(`  Base Reserves: ${baseReserves.toString()}`)
+    this.log(`  Quote Reserves: ${quoteReserves.toString()}`)
+    this.log('')
+    this.log('Constant Product Params:')
+    this.log(`  Virtual SOL: ${bucket.constantProductParams.virtualSol.toString()}`)
+    this.log(`  Virtual Tokens: ${bucket.constantProductParams.virtualTokens.toString()}`)
+    this.log('')
+    this.log('Status:')
+    this.log(`  First Buy Pending: ${firstBuyPending ? 'Yes' : 'No'}`)
+    this.log(`  Swappable: ${swappable ? 'Yes' : 'No'}`)
+    this.log(`  Sold Out: ${soldOut ? 'Yes' : 'No'}`)
+    this.log(`  Fill Percentage: ${fillPct.toFixed(2)}%`)
+    this.log('')
+    this.log('Conditions:')
+    this.log(`  Swap Start: ${formatCondition(bucket.swapStartCondition)}`)
+    this.log(`  Swap End: ${formatCondition(bucket.swapEndCondition)}`)
+    this.log('')
+    this.log('Fees:')
+    this.log(`  Deposit Fee: ${bucket.depositFee.toString()}`)
+    this.log(`  Withdraw Fee: ${bucket.withdrawFee.toString()}`)
+    this.log(`  Creator Fee Accrued: ${bucket.creatorFeeAccrued.toString()}`)
+    this.log(`  Creator Fee Claimed: ${bucket.creatorFeeClaimed.toString()}`)
+    this.log('')
+    this.log('View on Explorer:')
+    this.log(
+      generateExplorerUrl(
+        this.context.explorer,
+        this.context.chain,
+        bucketPda,
+        'account'
+      )
+    )
+
+    return {
+      type: 'bonding-curve',
+      address: bucketPda.toString(),
+      genesisAccount: bucket.bucket.genesis.toString(),
+      bucketIndex: bucket.bucket.bucketIndex,
+      baseTokenAllocation: bucket.bucket.baseTokenAllocation.toString(),
+      baseTokenBalance: bucket.bucket.baseTokenBalance.toString(),
+      quoteTokenDepositTotal: bucket.quoteTokenDepositTotal.toString(),
+      currentPrice: price.toString(),
+      currentPriceQuotePerBase: priceQuotePerBase.toString(),
+      baseReserves: baseReserves.toString(),
+      quoteReserves: quoteReserves.toString(),
+      virtualSol: bucket.constantProductParams.virtualSol.toString(),
+      virtualTokens: bucket.constantProductParams.virtualTokens.toString(),
+      firstBuyPending,
+      swappable,
+      soldOut,
+      fillPercentage: fillPct,
+      creatorFeeAccrued: bucket.creatorFeeAccrued.toString(),
+      creatorFeeClaimed: bucket.creatorFeeClaimed.toString(),
       explorer: generateExplorerUrl(this.context.explorer, this.context.chain, bucketPda, 'account'),
     }
   }

--- a/src/commands/genesis/index.ts
+++ b/src/commands/genesis/index.ts
@@ -9,6 +9,8 @@ export default class Genesis extends Command {
     '<%= config.bin %> genesis deposit GenesisAddress123... --amount 1000',
     '<%= config.bin %> genesis claim GenesisAddress123...',
     '<%= config.bin %> genesis finalize GenesisAddress123...',
+    '<%= config.bin %> genesis swap GenesisAddress123... --direction buy --amount 100000000',
+    '<%= config.bin %> genesis swap GenesisAddress123... --info',
   ]
 
   public async run(): Promise<void> {
@@ -23,6 +25,7 @@ export default class Genesis extends Command {
     this.log('  genesis withdraw       Withdraw from a launch pool')
     this.log('  genesis claim          Claim tokens from a completed launch')
     this.log('  genesis claim-unlocked Claim tokens from an unlocked bucket')
+    this.log('  genesis swap           Buy/sell on a bonding curve (also: --info for status & quotes)')
     this.log('  genesis transition     Execute end behaviors for a bucket')
     this.log('  genesis finalize       Finalize a Genesis launch')
     this.log('  genesis revoke         Revoke/cancel a Genesis launch')

--- a/src/commands/genesis/launch/create.ts
+++ b/src/commands/genesis/launch/create.ts
@@ -5,6 +5,7 @@ import {
   GenesisApiConfig,
   LockedAllocation,
   QuoteMintInput,
+  RegisterLaunchInput,
   SvmNetwork,
   createAndRegisterLaunch,
 } from '@metaplex-foundation/genesis'
@@ -303,6 +304,16 @@ Use --wizard for an interactive guided setup.`
       default: false,
     }),
 
+    // Registration options
+    creatorWallet: Flags.string({
+      description: 'Override the launch owner wallet for registration (public key address)',
+      required: false,
+    }),
+    twitterVerificationToken: Flags.string({
+      description: 'Twitter verification token for verified badge on the launch page',
+      required: false,
+    }),
+
     // Optional
     lockedAllocations: Flags.string({
       description: '[launchpool only] Path to JSON file with locked allocation configs',
@@ -382,6 +393,11 @@ Use --wizard for an interactive guided setup.`
       this.error(errors.join('\n'))
     }
 
+    // Validate registration flags
+    if (flags.creatorWallet && !isPublicKey(flags.creatorWallet)) {
+      this.error('--creatorWallet must be a valid public key')
+    }
+
     // Validate agent flags
     if (flags.agentMint && !isPublicKey(flags.agentMint)) {
       this.error('--agentMint must be a valid public key (agent NFT mint address)')
@@ -426,7 +442,11 @@ Use --wizard for an interactive guided setup.`
 
     const launchInput = strategy.buildInput(common, flagRecord)
 
-    return this.sendLaunch(launchInput, flags.apiUrl ?? getDefaultApiUrl(network))
+    const registerOptions: Omit<RegisterLaunchInput, 'genesisAccount' | 'createLaunchInput'> = {}
+    if (flags.creatorWallet) registerOptions.creatorWallet = flags.creatorWallet
+    if (flags.twitterVerificationToken) registerOptions.twitterVerificationToken = flags.twitterVerificationToken
+
+    return this.sendLaunch(launchInput, flags.apiUrl ?? getDefaultApiUrl(network), registerOptions)
   }
 
   /* ------------------------------------------------------------------ */
@@ -480,14 +500,18 @@ Use --wizard for an interactive guided setup.`
       networkOverride,
     )
 
-    return this.sendLaunch(launchInput, (flags.apiUrl as string | undefined) ?? getDefaultApiUrl(network))
+    const registerOptions: Omit<RegisterLaunchInput, 'genesisAccount' | 'createLaunchInput'> = {}
+    if (flags.creatorWallet) registerOptions.creatorWallet = flags.creatorWallet as string
+    if (flags.twitterVerificationToken) registerOptions.twitterVerificationToken = flags.twitterVerificationToken as string
+
+    return this.sendLaunch(launchInput, (flags.apiUrl as string | undefined) ?? getDefaultApiUrl(network), registerOptions)
   }
 
   /* ------------------------------------------------------------------ */
   /*  Send launch (shared by wizard and flag modes)                      */
   /* ------------------------------------------------------------------ */
 
-  private async sendLaunch(launchInput: CreateLaunchInput, apiUrl: string): Promise<unknown> {
+  private async sendLaunch(launchInput: CreateLaunchInput, apiUrl: string, registerOptions?: Omit<RegisterLaunchInput, 'genesisAccount' | 'createLaunchInput'>): Promise<unknown> {
     const spinner = ora('Creating token launch via Genesis API...').start()
 
     try {
@@ -507,6 +531,7 @@ Use --wizard for an interactive guided setup.`
         apiConfig,
         launchInput,
         { commitment },
+        registerOptions,
       )
 
       spinner.succeed('Token launch created and registered successfully!')

--- a/src/commands/genesis/launch/create.ts
+++ b/src/commands/genesis/launch/create.ts
@@ -16,61 +16,69 @@ import ora from 'ora'
 import { TransactionCommand } from '../../../TransactionCommand.js'
 import { generateExplorerUrl } from '../../../explorers.js'
 import { readJsonSync } from '../../../lib/file.js'
-import { detectSvmNetwork, txSignatureToString } from '../../../lib/util.js'
 import { promptLaunchWizard, toISOTimestamp } from '../../../lib/genesis/createGenesisWizardPrompt.js'
 import { buildLaunchInput, getDefaultApiUrl } from '../../../lib/genesis/launchApi.js'
+import { detectSvmNetwork, txSignatureToString } from '../../../lib/util.js'
 
 /* ------------------------------------------------------------------ */
 /*  Launch strategy types & implementations                            */
 /* ------------------------------------------------------------------ */
 
 interface CommonLaunchParams {
-  wallet: string
-  token: {
-    name: string
-    symbol: string
-    image: string
-    description?: string
-    externalLinks?: Record<string, string>
-  }
-  network: SvmNetwork
-  quoteMint?: QuoteMintInput
   agent?: {
     mint: string
     setToken: boolean
   }
+  network: SvmNetwork
+  quoteMint?: QuoteMintInput
+  token: {
+    description?: string
+    externalLinks?: Record<string, string>
+    image: string
+    name: string
+    symbol: string
+  }
+  wallet: string
 }
 
 interface LaunchStrategy {
-  requiredFlags: string[]
-  disallowedFlags: string[]
-  validate(flags: Record<string, unknown>): string[]
   buildInput(common: CommonLaunchParams, flags: Record<string, unknown>): CreateLaunchInput
+  disallowedFlags: string[]
+  requiredFlags: string[]
+  validate(flags: Record<string, unknown>): string[]
 }
 
 const LAUNCH_STRATEGIES: Record<string, LaunchStrategy> = {
-  'launchpool': {
-    requiredFlags: ['tokenAllocation', 'raiseGoal', 'raydiumLiquidityBps', 'fundsRecipient'],
-    disallowedFlags: ['creatorFeeWallet', 'firstBuyAmount'],
+  'bonding-curve': {
+    buildInput(common, flags): CreateBondingCurveLaunchInput {
+      return {
+        ...common,
+        launch: {
+          ...(typeof flags.creatorFeeWallet === 'string' && { creatorFeeWallet: flags.creatorFeeWallet }),
+          ...(typeof flags.firstBuyAmount === 'number' && flags.firstBuyAmount > 0 && { firstBuyAmount: flags.firstBuyAmount }),
+        },
+        launchType: 'bondingCurve',
+      }
+    },
+    disallowedFlags: ['tokenAllocation', 'raiseGoal', 'raydiumLiquidityBps', 'fundsRecipient', 'lockedAllocations', 'depositStartTime'],
+
+    requiredFlags: [],
 
     validate(flags) {
       const errors: string[] = []
-      if (typeof flags.tokenAllocation === 'number' && flags.tokenAllocation <= 0) {
-        errors.push('--tokenAllocation must be a positive number')
+      if (typeof flags.creatorFeeWallet === 'string' && !isPublicKey(flags.creatorFeeWallet)) {
+        errors.push('--creatorFeeWallet must be a valid public key')
       }
-      if (typeof flags.raiseGoal === 'number' && flags.raiseGoal <= 0) {
-        errors.push('--raiseGoal must be a positive number')
+
+      if (typeof flags.firstBuyAmount === 'number' && flags.firstBuyAmount < 0) {
+        errors.push('--firstBuyAmount must be non-negative')
       }
-      if (typeof flags.raydiumLiquidityBps === 'number' &&
-          (flags.raydiumLiquidityBps < 2000 || flags.raydiumLiquidityBps > 10000)) {
-        errors.push('--raydiumLiquidityBps must be between 2000 and 10000 (20%-100%)')
-      }
-      if (typeof flags.fundsRecipient === 'string' && !isPublicKey(flags.fundsRecipient)) {
-        errors.push('--fundsRecipient must be a valid public key')
-      }
+
       return errors
     },
+  },
 
+  'launchpool': {
     buildInput(common, flags): CreateLaunchpoolLaunchInput {
       let lockedAllocations: LockedAllocation[] | undefined
       if (typeof flags.lockedAllocations === 'string') {
@@ -79,45 +87,43 @@ const LAUNCH_STRATEGIES: Record<string, LaunchStrategy> = {
 
       return {
         ...common,
-        launchType: 'launchpool',
         launch: {
           launchpool: {
-            tokenAllocation: flags.tokenAllocation as number,
             depositStartTime: flags.depositStartTime as string,
+            fundsRecipient: flags.fundsRecipient as string,
             raiseGoal: flags.raiseGoal as number,
             raydiumLiquidityBps: flags.raydiumLiquidityBps as number,
-            fundsRecipient: flags.fundsRecipient as string,
+            tokenAllocation: flags.tokenAllocation as number,
           },
           ...(lockedAllocations && { lockedAllocations }),
         },
+        launchType: 'launchpool',
       }
     },
-  },
+    disallowedFlags: ['creatorFeeWallet', 'firstBuyAmount'],
 
-  'bonding-curve': {
-    requiredFlags: [],
-    disallowedFlags: ['tokenAllocation', 'raiseGoal', 'raydiumLiquidityBps', 'fundsRecipient', 'lockedAllocations', 'depositStartTime'],
+    requiredFlags: ['tokenAllocation', 'raiseGoal', 'raydiumLiquidityBps', 'fundsRecipient'],
 
     validate(flags) {
       const errors: string[] = []
-      if (typeof flags.creatorFeeWallet === 'string' && !isPublicKey(flags.creatorFeeWallet)) {
-        errors.push('--creatorFeeWallet must be a valid public key')
+      if (typeof flags.tokenAllocation === 'number' && flags.tokenAllocation <= 0) {
+        errors.push('--tokenAllocation must be a positive number')
       }
-      if (typeof flags.firstBuyAmount === 'number' && flags.firstBuyAmount < 0) {
-        errors.push('--firstBuyAmount must be non-negative')
-      }
-      return errors
-    },
 
-    buildInput(common, flags): CreateBondingCurveLaunchInput {
-      return {
-        ...common,
-        launchType: 'bondingCurve',
-        launch: {
-          ...(typeof flags.creatorFeeWallet === 'string' && { creatorFeeWallet: flags.creatorFeeWallet }),
-          ...(typeof flags.firstBuyAmount === 'number' && flags.firstBuyAmount > 0 && { firstBuyAmount: flags.firstBuyAmount }),
-        },
+      if (typeof flags.raiseGoal === 'number' && flags.raiseGoal <= 0) {
+        errors.push('--raiseGoal must be a positive number')
       }
+
+      if (typeof flags.raydiumLiquidityBps === 'number' &&
+          (flags.raydiumLiquidityBps < 2000 || flags.raydiumLiquidityBps > 10_000)) {
+        errors.push('--raydiumLiquidityBps must be between 2000 and 10000 (20%-100%)')
+      }
+
+      if (typeof flags.fundsRecipient === 'string' && !isPublicKey(flags.fundsRecipient)) {
+        errors.push('--fundsRecipient must be a valid public key')
+      }
+
+      return errors
     },
   },
 }
@@ -130,48 +136,57 @@ function parseLockedAllocations(filePath: string): LockedAllocation[] {
   let parsed: unknown
   try {
     parsed = readJsonSync(filePath)
-  } catch (err) {
-    if (err && typeof err === 'object' && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
       throw new Error(`Locked allocations file not found: ${filePath}`)
     }
-    throw err
+
+    throw error
   }
 
   if (!Array.isArray(parsed)) {
-    throw new Error('Locked allocations file must contain a JSON array')
+    throw new TypeError('Locked allocations file must contain a JSON array')
   }
 
   const validTimeUnits = new Set(['SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'TWO_WEEKS', 'MONTH', 'QUARTER', 'YEAR'])
-  for (let i = 0; i < parsed.length; i++) {
-    const entry = parsed[i]
+  for (const [i, entry] of parsed.entries()) {
     if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
       throw new Error(`Locked allocation [${i}]: entry must be an object`)
     }
+
     if (typeof entry.name !== 'string' || entry.name.length === 0) {
       throw new Error(`Locked allocation [${i}]: "name" must be a non-empty string`)
     }
+
     if (typeof entry.recipient !== 'string' || !isPublicKey(entry.recipient)) {
       throw new Error(`Locked allocation [${i}]: "recipient" must be a valid public key`)
     }
+
     if (typeof entry.tokenAmount !== 'number' || entry.tokenAmount <= 0) {
       throw new Error(`Locked allocation [${i}]: "tokenAmount" must be a positive number`)
     }
+
     if (typeof entry.vestingStartTime !== 'string' || entry.vestingStartTime.length === 0) {
       throw new Error(`Locked allocation [${i}]: "vestingStartTime" must be a non-empty date string`)
     }
+
     if (!entry.vestingDuration || typeof entry.vestingDuration.value !== 'number' || !validTimeUnits.has(entry.vestingDuration.unit)) {
       throw new Error(`Locked allocation [${i}]: "vestingDuration" must have a numeric "value" and a valid "unit"`)
     }
+
     if (!validTimeUnits.has(entry.unlockSchedule)) {
       throw new Error(`Locked allocation [${i}]: "unlockSchedule" must be a valid time unit`)
     }
+
     if (entry.cliff !== undefined) {
       if (typeof entry.cliff !== 'object' || entry.cliff === null) {
         throw new Error(`Locked allocation [${i}]: "cliff" must be an object`)
       }
+
       if (!entry.cliff.duration || typeof entry.cliff.duration.value !== 'number' || !validTimeUnits.has(entry.cliff.duration.unit)) {
         throw new Error(`Locked allocation [${i}]: "cliff.duration" must have a numeric "value" and a valid "unit"`)
       }
+
       if (entry.cliff.unlockAmount !== undefined && (typeof entry.cliff.unlockAmount !== 'number' || entry.cliff.unlockAmount < 0)) {
         throw new Error(`Locked allocation [${i}]: "cliff.unlockAmount" must be a non-negative number`)
       }
@@ -215,68 +230,42 @@ Use --wizard for an interactive guided setup.`
   ]
 
   static override flags = {
-    // Wizard mode
-    wizard: Flags.boolean({
-      description: 'Interactive guided setup wizard',
+    // Agent mode
+    agentMint: Flags.string({
+      description: 'Agent NFT mint address. Wraps transactions for agent execution, enabling AI agents to launch tokens.',
+      required: false,
+    }),
+
+    agentSetToken: Flags.boolean({
       default: false,
+      description: 'When using --agentMint, set the launched token on the agent NFT.',
     }),
 
-    // Launch type
-    launchType: Flags.option({
-      description: 'Launch type: launchpool (default) or bonding-curve',
-      options: ['launchpool', 'bonding-curve'] as const,
-      default: 'launchpool' as const,
-    })(),
-
-    // Token metadata
-    name: Flags.string({
-      char: 'n',
-      description: 'Name of the token (1-32 characters)',
+    apiUrl: Flags.string({
+      description: 'Genesis API base URL (defaults to https://api.metaplex.com for mainnet, https://api.metaplex.dev for devnet)',
       required: false,
     }),
-    symbol: Flags.string({
-      char: 's',
-      description: 'Symbol of the token (1-10 characters)',
+    // Bonding curve config
+    creatorFeeWallet: Flags.string({
+      description: '[bonding-curve only] Wallet address to receive creator fees (defaults to launching wallet)',
       required: false,
     }),
-    image: Flags.string({
-      description: 'Token image URL',
+    // Registration options
+    creatorWallet: Flags.string({
+      description: 'Override the launch owner wallet for registration (public key address)',
+      required: false,
+    }),
+    // Shared config
+    depositStartTime: Flags.string({
+      description: '[launchpool only] Deposit start time (ISO date string or unix timestamp). 48h deposit period.',
       required: false,
     }),
     description: Flags.string({
       description: 'Token description (max 250 characters)',
       required: false,
     }),
-    website: Flags.string({
-      description: 'Project website URL',
-      required: false,
-    }),
-    twitter: Flags.string({
-      description: 'Project Twitter URL',
-      required: false,
-    }),
-    telegram: Flags.string({
-      description: 'Project Telegram URL',
-      required: false,
-    }),
-
-    // Shared config
-    depositStartTime: Flags.string({
-      description: '[launchpool only] Deposit start time (ISO date string or unix timestamp). 48h deposit period.',
-      required: false,
-    }),
-
-    // Project-only launchpool config
-    tokenAllocation: Flags.integer({
-      description: '[launchpool only] Launch pool token allocation (portion of 1B total supply)',
-      required: false,
-    }),
-    raiseGoal: Flags.integer({
-      description: '[launchpool only] Raise goal in whole units (e.g., 200 for 200 SOL)',
-      required: false,
-    }),
-    raydiumLiquidityBps: Flags.integer({
-      description: '[launchpool only] Raydium liquidity in basis points (2000-10000, i.e. 20%-100%)',
+    firstBuyAmount: Flags.string({
+      description: '[bonding-curve only] SOL amount for mandatory first buy (e.g. 0.1 for 0.1 SOL). Omit to disable.',
       required: false,
     }),
     fundsRecipient: Flags.string({
@@ -284,53 +273,79 @@ Use --wizard for an interactive guided setup.`
       required: false,
     }),
 
-    // Bonding curve config
-    creatorFeeWallet: Flags.string({
-      description: '[bonding-curve only] Wallet address to receive creator fees (defaults to launching wallet)',
-      required: false,
-    }),
-    firstBuyAmount: Flags.string({
-      description: '[bonding-curve only] SOL amount for mandatory first buy (e.g. 0.1 for 0.1 SOL). Omit to disable.',
+    image: Flags.string({
+      description: 'Token image URL',
       required: false,
     }),
 
-    // Agent mode
-    agentMint: Flags.string({
-      description: 'Agent NFT mint address. Wraps transactions for agent execution, enabling AI agents to launch tokens.',
-      required: false,
-    }),
-    agentSetToken: Flags.boolean({
-      description: 'When using --agentMint, set the launched token on the agent NFT.',
-      default: false,
-    }),
-
-    // Registration options
-    creatorWallet: Flags.string({
-      description: 'Override the launch owner wallet for registration (public key address)',
-      required: false,
-    }),
-    twitterVerificationToken: Flags.string({
-      description: 'Twitter verification token for verified badge on the launch page',
-      required: false,
-    }),
-
+    // Launch type
+    launchType: Flags.option({
+      default: 'launchpool' as const,
+      description: 'Launch type: launchpool (default) or bonding-curve',
+      options: ['launchpool', 'bonding-curve'] as const,
+    })(),
     // Optional
     lockedAllocations: Flags.string({
       description: '[launchpool only] Path to JSON file with locked allocation configs',
       required: false,
     }),
-    quoteMint: Flags.string({
-      description: 'Quote mint: SOL (default), USDC, or a mint address',
-      default: 'SOL',
+    // Token metadata
+    name: Flags.string({
+      char: 'n',
+      description: 'Name of the token (1-32 characters)',
+      required: false,
     }),
     network: Flags.option({
       description: 'Network override (auto-detected from RPC if not set)',
       options: ['solana-mainnet', 'solana-devnet'] as const,
       required: false,
     })(),
-    apiUrl: Flags.string({
-      description: 'Genesis API base URL (defaults to https://api.metaplex.com for mainnet, https://api.metaplex.dev for devnet)',
+
+    quoteMint: Flags.string({
+      default: 'SOL',
+      description: 'Quote mint: SOL (default), USDC, or a mint address',
+    }),
+    raiseGoal: Flags.integer({
+      description: '[launchpool only] Raise goal in whole units (e.g., 200 for 200 SOL)',
       required: false,
+    }),
+
+    raydiumLiquidityBps: Flags.integer({
+      description: '[launchpool only] Raydium liquidity in basis points (2000-10000, i.e. 20%-100%)',
+      required: false,
+    }),
+    symbol: Flags.string({
+      char: 's',
+      description: 'Symbol of the token (1-10 characters)',
+      required: false,
+    }),
+
+    telegram: Flags.string({
+      description: 'Project Telegram URL',
+      required: false,
+    }),
+    // Project-only launchpool config
+    tokenAllocation: Flags.integer({
+      description: '[launchpool only] Launch pool token allocation (portion of 1B total supply)',
+      required: false,
+    }),
+
+    twitter: Flags.string({
+      description: 'Project Twitter URL',
+      required: false,
+    }),
+    twitterVerificationToken: Flags.string({
+      description: 'Twitter verification token for verified badge on the launch page',
+      required: false,
+    }),
+    website: Flags.string({
+      description: 'Project website URL',
+      required: false,
+    }),
+    // Wizard mode
+    wizard: Flags.boolean({
+      default: false,
+      description: 'Interactive guided setup wizard',
     }),
   }
 
@@ -367,9 +382,10 @@ Use --wizard for an interactive guided setup.`
     // Parse firstBuyAmount as a number
     if (flags.firstBuyAmount) {
       const amount = Number(flags.firstBuyAmount)
-      if (isNaN(amount) || !Number.isFinite(amount) || amount < 0) {
+      if (Number.isNaN(amount) || !Number.isFinite(amount) || amount < 0) {
         this.error('--firstBuyAmount must be a finite, non-negative number (e.g. 0.1)')
       }
+
       flagRecord.firstBuyAmount = amount
     }
 
@@ -402,6 +418,7 @@ Use --wizard for an interactive guided setup.`
     if (flags.agentMint && !isPublicKey(flags.agentMint)) {
       this.error('--agentMint must be a valid public key (agent NFT mint address)')
     }
+
     if (flags.agentSetToken && !flags.agentMint) {
       this.error('--agentSetToken requires --agentMint')
     }
@@ -422,15 +439,15 @@ Use --wizard for an interactive guided setup.`
     const image = flags.image!
 
     const common: CommonLaunchParams = {
-      wallet: this.context.umi.identity.publicKey.toString(),
+      network,
       token: {
+        image,
         name,
         symbol,
-        image,
         ...(flags.description && { description: flags.description }),
         ...(Object.keys(externalLinks).length > 0 && { externalLinks }),
       },
-      network,
+      wallet: this.context.umi.identity.publicKey.toString(),
       ...(flags.quoteMint !== 'SOL' && { quoteMint: flags.quoteMint as QuoteMintInput }),
       ...(flags.agentMint && {
         agent: {
@@ -442,7 +459,7 @@ Use --wizard for an interactive guided setup.`
 
     const launchInput = strategy.buildInput(common, flagRecord)
 
-    const registerOptions: Omit<RegisterLaunchInput, 'genesisAccount' | 'createLaunchInput'> = {}
+    const registerOptions: Omit<RegisterLaunchInput, 'createLaunchInput' | 'genesisAccount'> = {}
     if (flags.creatorWallet) registerOptions.creatorWallet = flags.creatorWallet
     if (flags.twitterVerificationToken) registerOptions.twitterVerificationToken = flags.twitterVerificationToken
 
@@ -472,35 +489,35 @@ Use --wizard for an interactive guided setup.`
       this.context.umi.identity.publicKey.toString(),
       this.context.chain,
       {
+        agent: wizardResult.agentMint ? {
+          mint: wizardResult.agentMint,
+          setToken: wizardResult.agentSetToken ?? false,
+        } : undefined,
+        creatorFeeWallet: wizardResult.creatorFeeWallet,
+        depositStartTime: wizardResult.depositStartTime,
+        firstBuyAmount: wizardResult.firstBuyAmount,
+        fundsRecipient: wizardResult.fundsRecipient,
         launchType: wizardResult.launchType,
-        token: {
-          name: wizardResult.name,
-          symbol: wizardResult.symbol,
-          image: wizardResult.image,
-          ...(wizardResult.description && { description: wizardResult.description }),
-        },
+        quoteMint: wizardResult.quoteMint,
+        raiseGoal: wizardResult.raiseGoal,
+        raydiumLiquidityBps: wizardResult.raydiumLiquidityBps,
         socials: {
           ...(wizardResult.website && { website: wizardResult.website }),
           ...(wizardResult.twitter && { twitter: wizardResult.twitter }),
           ...(wizardResult.telegram && { telegram: wizardResult.telegram }),
         },
-        quoteMint: wizardResult.quoteMint,
-        depositStartTime: wizardResult.depositStartTime,
+        token: {
+          image: wizardResult.image,
+          name: wizardResult.name,
+          symbol: wizardResult.symbol,
+          ...(wizardResult.description && { description: wizardResult.description }),
+        },
         tokenAllocation: wizardResult.tokenAllocation,
-        raiseGoal: wizardResult.raiseGoal,
-        raydiumLiquidityBps: wizardResult.raydiumLiquidityBps,
-        fundsRecipient: wizardResult.fundsRecipient,
-        creatorFeeWallet: wizardResult.creatorFeeWallet,
-        firstBuyAmount: wizardResult.firstBuyAmount,
-        agent: wizardResult.agentMint ? {
-          mint: wizardResult.agentMint,
-          setToken: wizardResult.agentSetToken ?? false,
-        } : undefined,
       },
       networkOverride,
     )
 
-    const registerOptions: Omit<RegisterLaunchInput, 'genesisAccount' | 'createLaunchInput'> = {}
+    const registerOptions: Omit<RegisterLaunchInput, 'createLaunchInput' | 'genesisAccount'> = {}
     if (flags.creatorWallet) registerOptions.creatorWallet = flags.creatorWallet as string
     if (flags.twitterVerificationToken) registerOptions.twitterVerificationToken = flags.twitterVerificationToken as string
 
@@ -511,7 +528,7 @@ Use --wizard for an interactive guided setup.`
   /*  Send launch (shared by wizard and flag modes)                      */
   /* ------------------------------------------------------------------ */
 
-  private async sendLaunch(launchInput: CreateLaunchInput, apiUrl: string, registerOptions?: Omit<RegisterLaunchInput, 'genesisAccount' | 'createLaunchInput'>): Promise<unknown> {
+  private async sendLaunch(launchInput: CreateLaunchInput, apiUrl: string, registerOptions?: Omit<RegisterLaunchInput, 'createLaunchInput' | 'genesisAccount'>): Promise<unknown> {
     const spinner = ora('Creating token launch via Genesis API...').start()
 
     try {
@@ -545,6 +562,7 @@ Use --wizard for an interactive guided setup.`
       if (launchInput.agent) {
         this.log(`Agent Mint: ${typeof launchInput.agent.mint === 'string' ? launchInput.agent.mint : launchInput.agent.mint.toString()}`)
       }
+
       this.log('')
       this.log('Transactions:')
       for (const sig of result.signatures) {
@@ -565,12 +583,12 @@ Use --wizard for an interactive guided setup.`
 
       return {
         genesisAccount: result.genesisAccount,
-        mintAddress: result.mintAddress,
         launchId: result.launch.id,
         launchLink: result.launch.link,
+        mintAddress: result.mintAddress,
         signatures: result.signatures.map((sig: Uint8Array) => {
           const sigStr = txSignatureToString(sig)
-          return { signature: sigStr, explorer: generateExplorerUrl(this.context.explorer, this.context.chain, sigStr, 'transaction') }
+          return { explorer: generateExplorerUrl(this.context.explorer, this.context.chain, sigStr, 'transaction'), signature: sigStr }
         }),
       }
     } catch (error) {

--- a/src/commands/genesis/launch/register.ts
+++ b/src/commands/genesis/launch/register.ts
@@ -4,6 +4,7 @@ import {
   SvmNetwork,
   registerLaunch,
 } from '@metaplex-foundation/genesis'
+import { isPublicKey } from '@metaplex-foundation/umi'
 import { Args, Flags } from '@oclif/core'
 import ora from 'ora'
 
@@ -46,6 +47,14 @@ provided as a JSON file via --launchConfig.`
     })(),
     apiUrl: Flags.string({
       description: 'Genesis API base URL (defaults to https://api.metaplex.com for mainnet, https://api.metaplex.dev for devnet)',
+      required: false,
+    }),
+    creatorWallet: Flags.string({
+      description: 'Override the launch owner wallet for registration (public key address)',
+      required: false,
+    }),
+    twitterVerificationToken: Flags.string({
+      description: 'Twitter verification token for verified badge on the launch page',
       required: false,
     }),
   }
@@ -135,9 +144,16 @@ provided as a JSON file via --launchConfig.`
         baseUrl: flags.apiUrl ?? getDefaultApiUrl(network),
       }
 
+      // Validate registration flags
+      if (flags.creatorWallet && !isPublicKey(flags.creatorWallet)) {
+        throw new Error('--creatorWallet must be a valid public key')
+      }
+
       const result = await registerLaunch(this.context.umi, apiConfig, {
         genesisAccount: args.genesisAccount,
         createLaunchInput: launchConfig,
+        ...(flags.creatorWallet && { creatorWallet: flags.creatorWallet }),
+        ...(flags.twitterVerificationToken && { twitterVerificationToken: flags.twitterVerificationToken }),
       })
 
       if (result.existing) {

--- a/src/commands/genesis/launch/register.ts
+++ b/src/commands/genesis/launch/register.ts
@@ -10,10 +10,17 @@ import ora from 'ora'
 
 import { TransactionCommand } from '../../../TransactionCommand.js'
 import { readJsonSync } from '../../../lib/file.js'
-import { detectSvmNetwork } from '../../../lib/util.js'
 import { getDefaultApiUrl } from '../../../lib/genesis/launchApi.js'
+import { detectSvmNetwork } from '../../../lib/util.js'
 
 export default class GenesisLaunchRegister extends TransactionCommand<typeof GenesisLaunchRegister> {
+  static override args = {
+    genesisAccount: Args.string({
+      description: 'Genesis account address to register',
+      required: true,
+    }),
+  }
+
   static override description = `Register an existing genesis account with the Metaplex platform.
 
 Use this command if you created a genesis account using the low-level CLI commands
@@ -28,14 +35,15 @@ provided as a JSON file via --launchConfig.`
     '$ mplx genesis launch register <GENESIS_ACCOUNT> --launchConfig launch.json --network solana-devnet',
   ]
 
-  static override args = {
-    genesisAccount: Args.string({
-      description: 'Genesis account address to register',
-      required: true,
-    }),
-  }
-
   static override flags = {
+    apiUrl: Flags.string({
+      description: 'Genesis API base URL (defaults to https://api.metaplex.com for mainnet, https://api.metaplex.dev for devnet)',
+      required: false,
+    }),
+    creatorWallet: Flags.string({
+      description: 'Override the launch owner wallet for registration (public key address)',
+      required: false,
+    }),
     launchConfig: Flags.string({
       description: 'Path to JSON file with the launch configuration (same format as launch create input)',
       required: true,
@@ -45,14 +53,6 @@ provided as a JSON file via --launchConfig.`
       options: ['solana-mainnet', 'solana-devnet'] as const,
       required: false,
     })(),
-    apiUrl: Flags.string({
-      description: 'Genesis API base URL (defaults to https://api.metaplex.com for mainnet, https://api.metaplex.dev for devnet)',
-      required: false,
-    }),
-    creatorWallet: Flags.string({
-      description: 'Override the launch owner wallet for registration (public key address)',
-      required: false,
-    }),
     twitterVerificationToken: Flags.string({
       description: 'Twitter verification token for verified badge on the launch page',
       required: false,
@@ -75,32 +75,38 @@ provided as a JSON file via --launchConfig.`
       let parsed: unknown
       try {
         parsed = readJsonSync(filePath)
-      } catch (err) {
-        if (err && typeof err === 'object' && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+      } catch (error) {
+        if (error && typeof error === 'object' && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
           throw new Error(`Launch config file not found: ${filePath}`)
         }
-        throw err
+
+        throw error
       }
 
       if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
         throw new Error('Launch config must be a JSON object')
       }
+
       const config = parsed as Record<string, unknown>
 
       // Validate required top-level fields
       if (!config.token || typeof config.token !== 'object' || Array.isArray(config.token)) {
         throw new Error('Launch config is missing required "token" object (must include name, symbol, image)')
       }
+
       const token = config.token as Record<string, unknown>
       if (typeof token.name !== 'string' || typeof token.symbol !== 'string' || typeof token.image !== 'string') {
-        throw new Error('Launch config token must include string fields: "name", "symbol", "image"')
+        throw new TypeError('Launch config token must include string fields: "name", "symbol", "image"')
       }
+
       if (!config.launch || typeof config.launch !== 'object' || Array.isArray(config.launch)) {
         throw new Error('Launch config is missing required "launch" object')
       }
+
       if (config.launchType === undefined || config.launchType === null) {
         config.launchType = 'launchpool'
       }
+
       if (config.launchType !== 'launchpool' && config.launchType !== 'bondingCurve') {
         throw new Error(`Launch config "launchType" must be "launchpool" or "bondingCurve", got "${config.launchType}"`)
       }
@@ -111,20 +117,20 @@ provided as a JSON file via --launchConfig.`
         if (!launch.launchpool || typeof launch.launchpool !== 'object' || Array.isArray(launch.launchpool)) {
           throw new Error('Launchpool config requires a "launch.launchpool" object')
         }
+
         const pool = launch.launchpool as Record<string, unknown>
         if (!pool.tokenAllocation || !pool.depositStartTime || !pool.raiseGoal || !pool.raydiumLiquidityBps || !pool.fundsRecipient) {
           throw new Error('Launchpool config requires "tokenAllocation", "depositStartTime", "raiseGoal", "raydiumLiquidityBps", and "fundsRecipient" in launch.launchpool')
         }
       } else {
         // Bonding curve: validate optional fields when present
-        if (launch.creatorFeeWallet !== undefined) {
-          if (typeof launch.creatorFeeWallet !== 'string' || launch.creatorFeeWallet.length === 0) {
+        if (launch.creatorFeeWallet !== undefined && (typeof launch.creatorFeeWallet !== 'string' || launch.creatorFeeWallet.length === 0)) {
             throw new Error('Bonding curve "launch.creatorFeeWallet" must be a non-empty string (public key)')
           }
-        }
+
         if (launch.firstBuyAmount !== undefined) {
           const amount = Number(launch.firstBuyAmount)
-          if (isNaN(amount) || !Number.isFinite(amount) || amount < 0) {
+          if (Number.isNaN(amount) || !Number.isFinite(amount) || amount < 0) {
             throw new Error('Bonding curve "launch.firstBuyAmount" must be a finite, non-negative number')
           }
         }
@@ -150,8 +156,8 @@ provided as a JSON file via --launchConfig.`
       }
 
       const result = await registerLaunch(this.context.umi, apiConfig, {
-        genesisAccount: args.genesisAccount,
         createLaunchInput: launchConfig,
+        genesisAccount: args.genesisAccount,
         ...(flags.creatorWallet && { creatorWallet: flags.creatorWallet }),
         ...(flags.twitterVerificationToken && { twitterVerificationToken: flags.twitterVerificationToken }),
       })
@@ -169,11 +175,11 @@ provided as a JSON file via --launchConfig.`
       this.log(`Mint Address: ${result.token.mintAddress}`)
 
       return {
+        existing: result.existing,
         launchId: result.launch.id,
         launchLink: result.launch.link,
-        tokenId: result.token.id,
         mintAddress: result.token.mintAddress,
-        existing: result.existing,
+        tokenId: result.token.id,
       }
     } catch (error) {
       spinner.fail('Failed to register genesis account')

--- a/src/commands/genesis/swap.ts
+++ b/src/commands/genesis/swap.ts
@@ -1,18 +1,18 @@
 import {
-  swapBondingCurveV2,
-  safeFetchGenesisAccountV2,
-  findBondingCurveBucketV2Pda,
-  safeFetchBondingCurveBucketV2,
-  WRAPPED_SOL_MINT,
   SwapDirection,
-  getSwapResult,
+  WRAPPED_SOL_MINT,
   applySlippage,
-  isFirstBuyPending,
-  isSwappable,
-  isSoldOut,
+  findBondingCurveBucketV2Pda,
   getCurrentPrice,
   getCurrentPriceQuotePerBase,
   getFillPercentage,
+  getSwapResult,
+  isFirstBuyPending,
+  isSoldOut,
+  isSwappable,
+  safeFetchBondingCurveBucketV2,
+  safeFetchGenesisAccountV2,
+  swapBondingCurveV2,
 } from '@metaplex-foundation/genesis'
 import {
   createAssociatedToken,
@@ -20,18 +20,25 @@ import {
   syncNative,
   transferSol,
 } from '@metaplex-foundation/mpl-toolbox'
-import { publicKey, lamports, TransactionBuilder } from '@metaplex-foundation/umi'
+import { TransactionBuilder, lamports, publicKey } from '@metaplex-foundation/umi'
 import { Args, Flags } from '@oclif/core'
 import ora from 'ora'
 
 import { TransactionCommand } from '../../TransactionCommand.js'
 import { generateExplorerUrl } from '../../explorers.js'
-import { txSignatureToString } from '../../lib/util.js'
 import umiSendAndConfirmTransaction from '../../lib/umi/sendAndConfirm.js'
+import { txSignatureToString } from '../../lib/util.js'
 
 const NATIVE_MINT = publicKey(WRAPPED_SOL_MINT)
 
 export default class GenesisSwap extends TransactionCommand<typeof GenesisSwap> {
+  static override args = {
+    genesis: Args.string({
+      description: 'The Genesis account address',
+      required: true,
+    }),
+  }
+
   static override description = `Swap on a Genesis bonding curve.
 
 Buy tokens with quote tokens (e.g. SOL) or sell tokens back for quote tokens.
@@ -54,38 +61,31 @@ Combine --info with --buyAmount or --sellAmount to get a quote without swapping.
     '$ mplx genesis swap GenesisAddress... --info --sellAmount 500000000000',
   ]
 
-  static override usage = 'genesis swap [GENESIS] [FLAGS]'
-
-  static override args = {
-    genesis: Args.string({
-      description: 'The Genesis account address',
-      required: true,
-    }),
-  }
-
   static override flags = {
+    bucketIndex: Flags.integer({
+      char: 'b',
+      default: 0,
+      description: 'Index of the bonding curve bucket (default: 0)',
+    }),
     buyAmount: Flags.string({
       description: 'Amount of quote tokens to spend on buying base tokens (e.g. lamports for SOL)',
       required: false,
+    }),
+    info: Flags.boolean({
+      default: false,
+      description: 'Display curve status and price quotes without executing a swap',
     }),
     sellAmount: Flags.string({
       description: 'Amount of base tokens to sell for quote tokens',
       required: false,
     }),
     slippage: Flags.integer({
-      description: 'Slippage tolerance in basis points (default: 200 = 2%)',
       default: 200,
-    }),
-    bucketIndex: Flags.integer({
-      char: 'b',
-      description: 'Index of the bonding curve bucket (default: 0)',
-      default: 0,
-    }),
-    info: Flags.boolean({
-      description: 'Display curve status and price quotes without executing a swap',
-      default: false,
+      description: 'Slippage tolerance in basis points (default: 200 = 2%)',
     }),
   }
+
+  static override usage = 'genesis swap [GENESIS] [FLAGS]'
 
   public async run(): Promise<unknown> {
     const { args, flags } = await this.parse(GenesisSwap)
@@ -98,11 +98,12 @@ Combine --info with --buyAmount or --sellAmount to get a quote without swapping.
     if (!flags.buyAmount && !flags.sellAmount) {
       this.error('Either --buyAmount or --sellAmount is required. Use --info to view curve status without swapping.')
     }
+
     if (flags.buyAmount && flags.sellAmount) {
       this.error('Cannot specify both --buyAmount and --sellAmount. Use one or the other.')
     }
 
-    const isBuy = !!flags.buyAmount
+    const isBuy = Boolean(flags.buyAmount)
     const rawAmount = (flags.buyAmount ?? flags.sellAmount)!
 
     const spinner = ora('Processing swap...').start()
@@ -120,8 +121,8 @@ Combine --info with --buyAmount or --sellAmount to get a quote without swapping.
 
       // Fetch bonding curve bucket
       const [bucketPda] = findBondingCurveBucketV2Pda(this.context.umi, {
-        genesisAccount: genesisAddress,
         bucketIndex: flags.bucketIndex,
+        genesisAccount: genesisAddress,
       })
 
       spinner.text = 'Fetching bonding curve bucket...'
@@ -138,6 +139,7 @@ Combine --info with --buyAmount or --sellAmount to get a quote without swapping.
       } catch {
         this.error(`Invalid amount "${rawAmount}". Must be a non-negative integer.`)
       }
+
       if (amount <= 0n) {
         this.error('Swap amount must be greater than 0.')
       }
@@ -163,7 +165,7 @@ Combine --info with --buyAmount or --sellAmount to get a quote without swapping.
         const totalNeeded = amount + quote.fee + quote.creatorFee
         let currentBalance = 0n
         if (ataAccount && ataAccount.exists) {
-          const data = ataAccount.data
+          const {data} = ataAccount
           currentBalance = data.length >= 72
             ? BigInt(new DataView(data.buffer, data.byteOffset + 64, 8).getBigUint64(0, true))
             : 0n
@@ -194,14 +196,14 @@ Combine --info with --buyAmount or --sellAmount to get a quote without swapping.
       spinner.text = `Swapping ${isBuy ? 'quote → base' : 'base → quote'} tokens...`
 
       const swapIx = swapBondingCurveV2(this.context.umi, {
-        genesisAccount: genesisAddress,
-        bucket: bucketPda,
-        baseMint: genesisAccount.baseMint,
-        quoteMint: genesisAccount.quoteMint,
-        payer: this.context.payer,
-        swapDirection,
         amount,
+        baseMint: genesisAccount.baseMint,
+        bucket: bucketPda,
+        genesisAccount: genesisAddress,
         minAmountOutScaled: minAmountOut,
+        payer: this.context.payer,
+        quoteMint: genesisAccount.quoteMint,
+        swapDirection,
       })
 
       const transaction = wrapTx.add(swapIx)
@@ -228,16 +230,16 @@ Combine --info with --buyAmount or --sellAmount to get a quote without swapping.
       this.log(generateExplorerUrl(this.context.explorer, this.context.chain, sig, 'transaction'))
 
       return {
-        genesisAccount: genesisAddress.toString(),
-        bucket: bucketPda.toString(),
-        direction,
         amountIn: amount.toString(),
-        expectedOut: quote.amountOut.toString(),
-        minOut: minAmountOut.toString(),
-        fee: quote.fee.toString(),
+        bucket: bucketPda.toString(),
         creatorFee: quote.creatorFee.toString(),
-        signature: sig,
+        direction,
+        expectedOut: quote.amountOut.toString(),
         explorer: generateExplorerUrl(this.context.explorer, this.context.chain, sig, 'transaction'),
+        fee: quote.fee.toString(),
+        genesisAccount: genesisAddress.toString(),
+        minOut: minAmountOut.toString(),
+        signature: sig,
       }
     } catch (error) {
       spinner.fail('Failed to swap')
@@ -259,8 +261,8 @@ Combine --info with --buyAmount or --sellAmount to get a quote without swapping.
       }
 
       const [bucketPda] = findBondingCurveBucketV2Pda(this.context.umi, {
-        genesisAccount: genesisAddress,
         bucketIndex,
+        genesisAccount: genesisAddress,
       })
 
       const bucket = await safeFetchBondingCurveBucketV2(this.context.umi, bucketPda)
@@ -299,14 +301,14 @@ Combine --info with --buyAmount or --sellAmount to get a quote without swapping.
       this.log(`  Fill: ${fillPct.toFixed(2)}%`)
 
       const result: Record<string, unknown> = {
-        genesisAccount: genesisAddress.toString(),
         bucket: bucketPda.toString(),
+        fillPercentage: fillPct,
+        firstBuyPending: firstBuy,
+        genesisAccount: genesisAddress.toString(),
         price: price.toString(),
         priceQuotePerBase: priceQpB.toString(),
-        firstBuyPending: firstBuy,
-        swappable,
         soldOut,
-        fillPercentage: fillPct,
+        swappable,
       }
 
       // Buy quote
@@ -317,6 +319,7 @@ Combine --info with --buyAmount or --sellAmount to get a quote without swapping.
         } catch {
           this.error(`Invalid --buyAmount "${flags.buyAmount}". Must be a non-negative integer.`)
         }
+
         const buyQuote = getSwapResult(bucket, buyAmt, SwapDirection.Buy, firstBuy)
         const minOut = applySlippage(buyQuote.amountOut, (flags.slippage as number) ?? 200)
         this.log('')
@@ -328,8 +331,8 @@ Combine --info with --buyAmount or --sellAmount to get a quote without swapping.
         result.buyQuote = {
           amountIn: buyAmt.toString(),
           amountOut: buyQuote.amountOut.toString(),
-          fee: buyQuote.fee.toString(),
           creatorFee: buyQuote.creatorFee.toString(),
+          fee: buyQuote.fee.toString(),
           minOut: minOut.toString(),
         }
       }
@@ -342,6 +345,7 @@ Combine --info with --buyAmount or --sellAmount to get a quote without swapping.
         } catch {
           this.error(`Invalid --sellAmount "${flags.sellAmount}". Must be a non-negative integer.`)
         }
+
         const sellQuote = getSwapResult(bucket, sellAmt, SwapDirection.Sell, false)
         const minOut = applySlippage(sellQuote.amountOut, (flags.slippage as number) ?? 200)
         this.log('')
@@ -353,8 +357,8 @@ Combine --info with --buyAmount or --sellAmount to get a quote without swapping.
         result.sellQuote = {
           amountIn: sellAmt.toString(),
           amountOut: sellQuote.amountOut.toString(),
-          fee: sellQuote.fee.toString(),
           creatorFee: sellQuote.creatorFee.toString(),
+          fee: sellQuote.fee.toString(),
           minOut: minOut.toString(),
         }
       }

--- a/src/commands/genesis/swap.ts
+++ b/src/commands/genesis/swap.ts
@@ -3,6 +3,7 @@ import {
   safeFetchGenesisAccountV2,
   findBondingCurveBucketV2Pda,
   safeFetchBondingCurveBucketV2,
+  WRAPPED_SOL_MINT,
   SwapDirection,
   getSwapResult,
   applySlippage,
@@ -13,7 +14,13 @@ import {
   getCurrentPriceQuotePerBase,
   getFillPercentage,
 } from '@metaplex-foundation/genesis'
-import { publicKey } from '@metaplex-foundation/umi'
+import {
+  createAssociatedToken,
+  findAssociatedTokenPda,
+  syncNative,
+  transferSol,
+} from '@metaplex-foundation/mpl-toolbox'
+import { publicKey, sol, TransactionBuilder } from '@metaplex-foundation/umi'
 import { Args, Flags } from '@oclif/core'
 import ora from 'ora'
 
@@ -22,23 +29,29 @@ import { generateExplorerUrl } from '../../explorers.js'
 import { txSignatureToString } from '../../lib/util.js'
 import umiSendAndConfirmTransaction from '../../lib/umi/sendAndConfirm.js'
 
+const NATIVE_MINT = publicKey(WRAPPED_SOL_MINT)
+
 export default class GenesisSwap extends TransactionCommand<typeof GenesisSwap> {
   static override description = `Swap on a Genesis bonding curve.
 
 Buy tokens with quote tokens (e.g. SOL) or sell tokens back for quote tokens.
 The bonding curve uses a constant-product formula for pricing.
 
-Use --direction buy to purchase tokens (amount is in quote token base units, e.g. lamports).
-Use --direction sell to sell tokens (amount is in base token base units).
+When buying with SOL, the command automatically wraps SOL to WSOL if needed.
 
-Use --info to display curve status and price quotes without executing a swap.`
+Use --buyAmount to purchase tokens (amount is in quote token base units, e.g. lamports).
+Use --sellAmount to sell tokens (amount is in base token base units).
+
+Use --info to display curve status and price quotes without executing a swap.
+Combine --info with --buyAmount or --sellAmount to get a quote without swapping.`
 
   static override examples = [
-    '$ mplx genesis swap GenesisAddress... --direction buy --amount 100000000',
-    '$ mplx genesis swap GenesisAddress... --direction sell --amount 500000000000',
-    '$ mplx genesis swap GenesisAddress... --direction buy --amount 100000000 --slippage 300',
+    '$ mplx genesis swap GenesisAddress... --buyAmount 100000000',
+    '$ mplx genesis swap GenesisAddress... --sellAmount 500000000000',
+    '$ mplx genesis swap GenesisAddress... --buyAmount 100000000 --slippage 300',
     '$ mplx genesis swap GenesisAddress... --info',
-    '$ mplx genesis swap GenesisAddress... --info --quoteAmount 100000000',
+    '$ mplx genesis swap GenesisAddress... --info --buyAmount 100000000',
+    '$ mplx genesis swap GenesisAddress... --info --sellAmount 500000000000',
   ]
 
   static override usage = 'genesis swap [GENESIS] [FLAGS]'
@@ -51,15 +64,12 @@ Use --info to display curve status and price quotes without executing a swap.`
   }
 
   static override flags = {
-    direction: Flags.option({
-      char: 'd',
-      description: 'Swap direction: buy (quote → base tokens) or sell (base tokens → quote)',
-      options: ['buy', 'sell'] as const,
+    buyAmount: Flags.string({
+      description: 'Amount of quote tokens to spend on buying base tokens (e.g. lamports for SOL)',
       required: false,
-    })(),
-    amount: Flags.string({
-      char: 'a',
-      description: 'Amount to swap (in base units)',
+    }),
+    sellAmount: Flags.string({
+      description: 'Amount of base tokens to sell for quote tokens',
       required: false,
     }),
     slippage: Flags.integer({
@@ -72,16 +82,8 @@ Use --info to display curve status and price quotes without executing a swap.`
       default: 0,
     }),
     info: Flags.boolean({
-      description: 'Display curve status, price info, and optional quotes without swapping',
+      description: 'Display curve status and price quotes without executing a swap',
       default: false,
-    }),
-    quoteAmount: Flags.string({
-      description: '[--info only] Get a buy quote for this quote token amount (base units)',
-      required: false,
-    }),
-    sellAmount: Flags.string({
-      description: '[--info only] Get a sell quote for this base token amount (base units)',
-      required: false,
     }),
   }
 
@@ -92,13 +94,16 @@ Use --info to display curve status and price quotes without executing a swap.`
       return this.showCurveInfo(args.genesis, flags)
     }
 
-    // Validate required flags for swap
-    if (!flags.direction) {
-      this.error('--direction is required for swaps. Use --info to view curve status without swapping.')
+    // Validate: exactly one of --buyAmount or --sellAmount required for swap
+    if (!flags.buyAmount && !flags.sellAmount) {
+      this.error('Either --buyAmount or --sellAmount is required. Use --info to view curve status without swapping.')
     }
-    if (!flags.amount) {
-      this.error('--amount is required for swaps. Use --info to view curve status without swapping.')
+    if (flags.buyAmount && flags.sellAmount) {
+      this.error('Cannot specify both --buyAmount and --sellAmount. Use one or the other.')
     }
+
+    const isBuy = !!flags.buyAmount
+    const rawAmount = (flags.buyAmount ?? flags.sellAmount)!
 
     const spinner = ora('Processing swap...').start()
 
@@ -129,24 +134,66 @@ Use --info to display curve status and price quotes without executing a swap.`
       // Parse amount
       let amount: bigint
       try {
-        amount = BigInt(flags.amount)
+        amount = BigInt(rawAmount)
       } catch {
-        this.error(`Invalid amount "${flags.amount}". Must be a non-negative integer.`)
+        this.error(`Invalid amount "${rawAmount}". Must be a non-negative integer.`)
       }
       if (amount <= 0n) {
         this.error('Swap amount must be greater than 0.')
       }
 
-      const swapDirection = flags.direction === 'buy' ? SwapDirection.Buy : SwapDirection.Sell
+      const swapDirection = isBuy ? SwapDirection.Buy : SwapDirection.Sell
       const firstBuy = isFirstBuyPending(bucket)
 
       // Get quote
-      const quote = getSwapResult(bucket, amount, swapDirection, firstBuy)
+      const quote = getSwapResult(bucket, amount, swapDirection, isBuy && firstBuy)
       const minAmountOut = applySlippage(quote.amountOut, flags.slippage)
 
-      spinner.text = `Swapping ${flags.direction === 'buy' ? 'quote → base' : 'base → quote'} tokens...`
+      // Auto-wrap SOL if buying and quote mint is native SOL
+      let wrapTx = new TransactionBuilder()
+      const isNativeSol = genesisAccount.quoteMint.toString() === NATIVE_MINT.toString()
+      if (isBuy && isNativeSol) {
+        const [wsolAta] = findAssociatedTokenPda(this.context.umi, {
+          mint: NATIVE_MINT,
+          owner: this.context.umi.identity.publicKey,
+        })
 
-      const transaction = swapBondingCurveV2(this.context.umi, {
+        const ataAccount = await this.context.umi.rpc.getAccount(wsolAta).catch(() => null)
+
+        const totalNeeded = amount + quote.fee + quote.creatorFee
+        let currentBalance = 0n
+        if (ataAccount && ataAccount.exists) {
+          const data = ataAccount.data
+          currentBalance = data.length >= 72
+            ? BigInt(new DataView(data.buffer, data.byteOffset + 64, 8).getBigUint64(0, true))
+            : 0n
+        }
+
+        if (currentBalance < totalNeeded) {
+          const deficit = totalNeeded - currentBalance
+          spinner.text = `Auto-wrapping ${deficit} lamports to WSOL...`
+
+          if (!ataAccount || !ataAccount.exists) {
+            wrapTx = wrapTx.add(createAssociatedToken(this.context.umi, {
+              mint: NATIVE_MINT,
+              owner: this.context.umi.identity.publicKey,
+            }))
+          }
+
+          wrapTx = wrapTx.add(transferSol(this.context.umi, {
+            amount: sol(Number(deficit) / 1e9),
+            destination: wsolAta,
+          }))
+          wrapTx = wrapTx.add(syncNative(this.context.umi, {
+            account: wsolAta,
+          }))
+        }
+      }
+
+      const direction = isBuy ? 'buy' : 'sell'
+      spinner.text = `Swapping ${isBuy ? 'quote → base' : 'base → quote'} tokens...`
+
+      const swapIx = swapBondingCurveV2(this.context.umi, {
         genesisAccount: genesisAddress,
         bucket: bucketPda,
         baseMint: genesisAccount.baseMint,
@@ -157,6 +204,7 @@ Use --info to display curve status and price quotes without executing a swap.`
         minAmountOutScaled: minAmountOut,
       })
 
+      const transaction = wrapTx.add(swapIx)
       const result = await umiSendAndConfirmTransaction(this.context.umi, transaction)
 
       spinner.succeed('Swap successful!')
@@ -164,12 +212,12 @@ Use --info to display curve status and price quotes without executing a swap.`
       const sig = txSignatureToString(result.transaction.signature as Uint8Array)
 
       this.log('')
-      this.logSuccess(`${flags.direction === 'buy' ? 'Bought' : 'Sold'} tokens on bonding curve`)
+      this.logSuccess(`${isBuy ? 'Bought' : 'Sold'} tokens on bonding curve`)
       this.log('')
       this.log('Swap Details:')
       this.log(`  Genesis Account: ${genesisAddress}`)
       this.log(`  Bucket: ${bucketPda}`)
-      this.log(`  Direction: ${flags.direction}`)
+      this.log(`  Direction: ${direction}`)
       this.log(`  Amount In: ${amount.toString()}`)
       this.log(`  Expected Out: ${quote.amountOut.toString()}`)
       this.log(`  Min Out (with ${flags.slippage}bps slippage): ${minAmountOut.toString()}`)
@@ -182,7 +230,7 @@ Use --info to display curve status and price quotes without executing a swap.`
       return {
         genesisAccount: genesisAddress.toString(),
         bucket: bucketPda.toString(),
-        direction: flags.direction,
+        direction,
         amountIn: amount.toString(),
         expectedOut: quote.amountOut.toString(),
         minOut: minAmountOut.toString(),
@@ -262,18 +310,18 @@ Use --info to display curve status and price quotes without executing a swap.`
       }
 
       // Buy quote
-      if (typeof flags.quoteAmount === 'string') {
-        const quoteAmt = BigInt(flags.quoteAmount)
-        const buyQuote = getSwapResult(bucket, quoteAmt, SwapDirection.Buy, firstBuy)
+      if (typeof flags.buyAmount === 'string') {
+        const buyAmt = BigInt(flags.buyAmount)
+        const buyQuote = getSwapResult(bucket, buyAmt, SwapDirection.Buy, firstBuy)
         const minOut = applySlippage(buyQuote.amountOut, (flags.slippage as number) ?? 200)
         this.log('')
-        this.log(`Buy Quote (${quoteAmt.toString()} quote tokens in):`)
+        this.log(`Buy Quote (${buyAmt.toString()} quote tokens in):`)
         this.log(`  Tokens out: ${buyQuote.amountOut.toString()}`)
         this.log(`  Fee: ${buyQuote.fee.toString()}`)
         this.log(`  Creator Fee: ${buyQuote.creatorFee.toString()}`)
         this.log(`  Min out (${flags.slippage}bps slippage): ${minOut.toString()}`)
         result.buyQuote = {
-          amountIn: quoteAmt.toString(),
+          amountIn: buyAmt.toString(),
           amountOut: buyQuote.amountOut.toString(),
           fee: buyQuote.fee.toString(),
           creatorFee: buyQuote.creatorFee.toString(),

--- a/src/commands/genesis/swap.ts
+++ b/src/commands/genesis/swap.ts
@@ -1,0 +1,310 @@
+import {
+  swapBondingCurveV2,
+  safeFetchGenesisAccountV2,
+  findBondingCurveBucketV2Pda,
+  safeFetchBondingCurveBucketV2,
+  SwapDirection,
+  getSwapResult,
+  applySlippage,
+  isFirstBuyPending,
+  isSwappable,
+  isSoldOut,
+  getCurrentPrice,
+  getCurrentPriceQuotePerBase,
+  getFillPercentage,
+} from '@metaplex-foundation/genesis'
+import { publicKey } from '@metaplex-foundation/umi'
+import { Args, Flags } from '@oclif/core'
+import ora from 'ora'
+
+import { TransactionCommand } from '../../TransactionCommand.js'
+import { generateExplorerUrl } from '../../explorers.js'
+import { txSignatureToString } from '../../lib/util.js'
+import umiSendAndConfirmTransaction from '../../lib/umi/sendAndConfirm.js'
+
+export default class GenesisSwap extends TransactionCommand<typeof GenesisSwap> {
+  static override description = `Swap on a Genesis bonding curve.
+
+Buy tokens with quote tokens (e.g. SOL) or sell tokens back for quote tokens.
+The bonding curve uses a constant-product formula for pricing.
+
+Use --direction buy to purchase tokens (amount is in quote token base units, e.g. lamports).
+Use --direction sell to sell tokens (amount is in base token base units).
+
+Use --info to display curve status and price quotes without executing a swap.`
+
+  static override examples = [
+    '$ mplx genesis swap GenesisAddress... --direction buy --amount 100000000',
+    '$ mplx genesis swap GenesisAddress... --direction sell --amount 500000000000',
+    '$ mplx genesis swap GenesisAddress... --direction buy --amount 100000000 --slippage 300',
+    '$ mplx genesis swap GenesisAddress... --info',
+    '$ mplx genesis swap GenesisAddress... --info --quoteAmount 100000000',
+  ]
+
+  static override usage = 'genesis swap [GENESIS] [FLAGS]'
+
+  static override args = {
+    genesis: Args.string({
+      description: 'The Genesis account address',
+      required: true,
+    }),
+  }
+
+  static override flags = {
+    direction: Flags.option({
+      char: 'd',
+      description: 'Swap direction: buy (quote → base tokens) or sell (base tokens → quote)',
+      options: ['buy', 'sell'] as const,
+      required: false,
+    })(),
+    amount: Flags.string({
+      char: 'a',
+      description: 'Amount to swap (in base units)',
+      required: false,
+    }),
+    slippage: Flags.integer({
+      description: 'Slippage tolerance in basis points (default: 200 = 2%)',
+      default: 200,
+    }),
+    bucketIndex: Flags.integer({
+      char: 'b',
+      description: 'Index of the bonding curve bucket (default: 0)',
+      default: 0,
+    }),
+    info: Flags.boolean({
+      description: 'Display curve status, price info, and optional quotes without swapping',
+      default: false,
+    }),
+    quoteAmount: Flags.string({
+      description: '[--info only] Get a buy quote for this quote token amount (base units)',
+      required: false,
+    }),
+    sellAmount: Flags.string({
+      description: '[--info only] Get a sell quote for this base token amount (base units)',
+      required: false,
+    }),
+  }
+
+  public async run(): Promise<unknown> {
+    const { args, flags } = await this.parse(GenesisSwap)
+
+    if (flags.info) {
+      return this.showCurveInfo(args.genesis, flags)
+    }
+
+    // Validate required flags for swap
+    if (!flags.direction) {
+      this.error('--direction is required for swaps. Use --info to view curve status without swapping.')
+    }
+    if (!flags.amount) {
+      this.error('--amount is required for swaps. Use --info to view curve status without swapping.')
+    }
+
+    const spinner = ora('Processing swap...').start()
+
+    try {
+      const genesisAddress = publicKey(args.genesis)
+
+      // Fetch genesis account
+      spinner.text = 'Fetching Genesis account...'
+      const genesisAccount = await safeFetchGenesisAccountV2(this.context.umi, genesisAddress)
+      if (!genesisAccount) {
+        spinner.fail('Genesis account not found')
+        this.error(`Genesis account not found at address: ${args.genesis}`)
+      }
+
+      // Fetch bonding curve bucket
+      const [bucketPda] = findBondingCurveBucketV2Pda(this.context.umi, {
+        genesisAccount: genesisAddress,
+        bucketIndex: flags.bucketIndex,
+      })
+
+      spinner.text = 'Fetching bonding curve bucket...'
+      const bucket = await safeFetchBondingCurveBucketV2(this.context.umi, bucketPda)
+      if (!bucket) {
+        spinner.fail('Bonding curve bucket not found')
+        this.error(`Bonding curve bucket not found at index ${flags.bucketIndex}.`)
+      }
+
+      // Parse amount
+      let amount: bigint
+      try {
+        amount = BigInt(flags.amount)
+      } catch {
+        this.error(`Invalid amount "${flags.amount}". Must be a non-negative integer.`)
+      }
+      if (amount <= 0n) {
+        this.error('Swap amount must be greater than 0.')
+      }
+
+      const swapDirection = flags.direction === 'buy' ? SwapDirection.Buy : SwapDirection.Sell
+      const firstBuy = isFirstBuyPending(bucket)
+
+      // Get quote
+      const quote = getSwapResult(bucket, amount, swapDirection, firstBuy)
+      const minAmountOut = applySlippage(quote.amountOut, flags.slippage)
+
+      spinner.text = `Swapping ${flags.direction === 'buy' ? 'quote → base' : 'base → quote'} tokens...`
+
+      const transaction = swapBondingCurveV2(this.context.umi, {
+        genesisAccount: genesisAddress,
+        bucket: bucketPda,
+        baseMint: genesisAccount.baseMint,
+        quoteMint: genesisAccount.quoteMint,
+        payer: this.context.payer,
+        swapDirection,
+        amount,
+        minAmountOutScaled: minAmountOut,
+      })
+
+      const result = await umiSendAndConfirmTransaction(this.context.umi, transaction)
+
+      spinner.succeed('Swap successful!')
+
+      const sig = txSignatureToString(result.transaction.signature as Uint8Array)
+
+      this.log('')
+      this.logSuccess(`${flags.direction === 'buy' ? 'Bought' : 'Sold'} tokens on bonding curve`)
+      this.log('')
+      this.log('Swap Details:')
+      this.log(`  Genesis Account: ${genesisAddress}`)
+      this.log(`  Bucket: ${bucketPda}`)
+      this.log(`  Direction: ${flags.direction}`)
+      this.log(`  Amount In: ${amount.toString()}`)
+      this.log(`  Expected Out: ${quote.amountOut.toString()}`)
+      this.log(`  Min Out (with ${flags.slippage}bps slippage): ${minAmountOut.toString()}`)
+      this.log(`  Fee: ${quote.fee.toString()}`)
+      this.log(`  Creator Fee: ${quote.creatorFee.toString()}`)
+      this.log('')
+      this.log(`Transaction: ${sig}`)
+      this.log(generateExplorerUrl(this.context.explorer, this.context.chain, sig, 'transaction'))
+
+      return {
+        genesisAccount: genesisAddress.toString(),
+        bucket: bucketPda.toString(),
+        direction: flags.direction,
+        amountIn: amount.toString(),
+        expectedOut: quote.amountOut.toString(),
+        minOut: minAmountOut.toString(),
+        fee: quote.fee.toString(),
+        creatorFee: quote.creatorFee.toString(),
+        signature: sig,
+        explorer: generateExplorerUrl(this.context.explorer, this.context.chain, sig, 'transaction'),
+      }
+    } catch (error) {
+      spinner.fail('Failed to swap')
+      throw error
+    }
+  }
+
+  private async showCurveInfo(genesisArg: string, flags: Record<string, unknown>): Promise<unknown> {
+    const spinner = ora('Fetching curve info...').start()
+
+    try {
+      const genesisAddress = publicKey(genesisArg)
+      const bucketIndex = (flags.bucketIndex as number) ?? 0
+
+      const genesisAccount = await safeFetchGenesisAccountV2(this.context.umi, genesisAddress)
+      if (!genesisAccount) {
+        spinner.fail('Genesis account not found')
+        this.error(`Genesis account not found at address: ${genesisArg}`)
+      }
+
+      const [bucketPda] = findBondingCurveBucketV2Pda(this.context.umi, {
+        genesisAccount: genesisAddress,
+        bucketIndex,
+      })
+
+      const bucket = await safeFetchBondingCurveBucketV2(this.context.umi, bucketPda)
+      if (!bucket) {
+        spinner.fail('Bonding curve bucket not found')
+        this.error(`Bonding curve bucket not found at index ${bucketIndex}.`)
+      }
+
+      spinner.succeed('Curve info fetched!')
+
+      const price = getCurrentPrice(bucket)
+      const priceQpB = getCurrentPriceQuotePerBase(bucket)
+      const firstBuy = isFirstBuyPending(bucket)
+      const swappable = isSwappable(bucket)
+      const soldOut = isSoldOut(bucket)
+      const fillPct = getFillPercentage(bucket)
+
+      this.log('')
+      this.logSuccess('Bonding Curve Info')
+      this.log('')
+      this.log('Pricing:')
+      this.log(`  Tokens per quote unit: ${price.toString()}`)
+      this.log(`  Quote per token: ${priceQpB.toString()}`)
+      this.log('')
+      this.log('Reserves:')
+      this.log(`  Base Token Balance: ${bucket.bucket.baseTokenBalance.toString()}`)
+      this.log(`  Base Token Allocation: ${bucket.bucket.baseTokenAllocation.toString()}`)
+      this.log(`  Quote Token Total: ${bucket.quoteTokenDepositTotal.toString()}`)
+      this.log(`  Virtual SOL: ${bucket.constantProductParams.virtualSol.toString()}`)
+      this.log(`  Virtual Tokens: ${bucket.constantProductParams.virtualTokens.toString()}`)
+      this.log('')
+      this.log('Status:')
+      this.log(`  First Buy Pending: ${firstBuy ? 'Yes' : 'No'}`)
+      this.log(`  Swappable: ${swappable ? 'Yes' : 'No'}`)
+      this.log(`  Sold Out: ${soldOut ? 'Yes' : 'No'}`)
+      this.log(`  Fill: ${fillPct.toFixed(2)}%`)
+
+      const result: Record<string, unknown> = {
+        genesisAccount: genesisAddress.toString(),
+        bucket: bucketPda.toString(),
+        price: price.toString(),
+        priceQuotePerBase: priceQpB.toString(),
+        firstBuyPending: firstBuy,
+        swappable,
+        soldOut,
+        fillPercentage: fillPct,
+      }
+
+      // Buy quote
+      if (typeof flags.quoteAmount === 'string') {
+        const quoteAmt = BigInt(flags.quoteAmount)
+        const buyQuote = getSwapResult(bucket, quoteAmt, SwapDirection.Buy, firstBuy)
+        const minOut = applySlippage(buyQuote.amountOut, (flags.slippage as number) ?? 200)
+        this.log('')
+        this.log(`Buy Quote (${quoteAmt.toString()} quote tokens in):`)
+        this.log(`  Tokens out: ${buyQuote.amountOut.toString()}`)
+        this.log(`  Fee: ${buyQuote.fee.toString()}`)
+        this.log(`  Creator Fee: ${buyQuote.creatorFee.toString()}`)
+        this.log(`  Min out (${flags.slippage}bps slippage): ${minOut.toString()}`)
+        result.buyQuote = {
+          amountIn: quoteAmt.toString(),
+          amountOut: buyQuote.amountOut.toString(),
+          fee: buyQuote.fee.toString(),
+          creatorFee: buyQuote.creatorFee.toString(),
+          minOut: minOut.toString(),
+        }
+      }
+
+      // Sell quote
+      if (typeof flags.sellAmount === 'string') {
+        const sellAmt = BigInt(flags.sellAmount)
+        const sellQuote = getSwapResult(bucket, sellAmt, SwapDirection.Sell, false)
+        const minOut = applySlippage(sellQuote.amountOut, (flags.slippage as number) ?? 200)
+        this.log('')
+        this.log(`Sell Quote (${sellAmt.toString()} base tokens in):`)
+        this.log(`  Quote tokens out: ${sellQuote.amountOut.toString()}`)
+        this.log(`  Fee: ${sellQuote.fee.toString()}`)
+        this.log(`  Creator Fee: ${sellQuote.creatorFee.toString()}`)
+        this.log(`  Min out (${flags.slippage}bps slippage): ${minOut.toString()}`)
+        result.sellQuote = {
+          amountIn: sellAmt.toString(),
+          amountOut: sellQuote.amountOut.toString(),
+          fee: sellQuote.fee.toString(),
+          creatorFee: sellQuote.creatorFee.toString(),
+          minOut: minOut.toString(),
+        }
+      }
+
+      return result
+    } catch (error) {
+      spinner.fail('Failed to fetch curve info')
+      throw error
+    }
+  }
+}

--- a/src/commands/genesis/swap.ts
+++ b/src/commands/genesis/swap.ts
@@ -20,7 +20,7 @@ import {
   syncNative,
   transferSol,
 } from '@metaplex-foundation/mpl-toolbox'
-import { publicKey, sol, TransactionBuilder } from '@metaplex-foundation/umi'
+import { publicKey, lamports, TransactionBuilder } from '@metaplex-foundation/umi'
 import { Args, Flags } from '@oclif/core'
 import ora from 'ora'
 
@@ -181,7 +181,7 @@ Combine --info with --buyAmount or --sellAmount to get a quote without swapping.
           }
 
           wrapTx = wrapTx.add(transferSol(this.context.umi, {
-            amount: sol(Number(deficit) / 1e9),
+            amount: lamports(deficit),
             destination: wsolAta,
           }))
           wrapTx = wrapTx.add(syncNative(this.context.umi, {
@@ -311,7 +311,12 @@ Combine --info with --buyAmount or --sellAmount to get a quote without swapping.
 
       // Buy quote
       if (typeof flags.buyAmount === 'string') {
-        const buyAmt = BigInt(flags.buyAmount)
+        let buyAmt: bigint
+        try {
+          buyAmt = BigInt(flags.buyAmount)
+        } catch {
+          this.error(`Invalid --buyAmount "${flags.buyAmount}". Must be a non-negative integer.`)
+        }
         const buyQuote = getSwapResult(bucket, buyAmt, SwapDirection.Buy, firstBuy)
         const minOut = applySlippage(buyQuote.amountOut, (flags.slippage as number) ?? 200)
         this.log('')
@@ -331,7 +336,12 @@ Combine --info with --buyAmount or --sellAmount to get a quote without swapping.
 
       // Sell quote
       if (typeof flags.sellAmount === 'string') {
-        const sellAmt = BigInt(flags.sellAmount)
+        let sellAmt: bigint
+        try {
+          sellAmt = BigInt(flags.sellAmount)
+        } catch {
+          this.error(`Invalid --sellAmount "${flags.sellAmount}". Must be a non-negative integer.`)
+        }
         const sellQuote = getSwapResult(bucket, sellAmt, SwapDirection.Sell, false)
         const minOut = applySlippage(sellQuote.amountOut, (flags.slippage as number) ?? 200)
         this.log('')

--- a/test/commands/genesis/genesis.swap.test.ts
+++ b/test/commands/genesis/genesis.swap.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+
 import { runCli } from '../../runCli'
 import { createGenesisAccount } from './genesishelpers'
 
@@ -9,7 +10,7 @@ describe('genesis swap and bonding curve commands', () => {
 
     before(async () => {
         await runCli(['toolbox', 'sol', 'airdrop', '100', 'TESTfCYwTPxME2cAnPcKvvF5xdPah3PY7naYQEP2kkx'])
-        await new Promise(resolve => setTimeout(resolve, 5000))
+        await new Promise<void>(resolve => { setTimeout(resolve, 5000) })
         await runCli(['toolbox', 'sol', 'wrap', '50'])
     })
 
@@ -112,10 +113,10 @@ describe('genesis swap and bonding curve commands', () => {
 
         it('reports not found for non-existent bonding curve bucket', async () => {
             const result = await createGenesisAccount({
+                decimals: 9,
                 name: 'BC Fetch Test',
                 symbol: 'BFT',
                 totalSupply: '1000000000',
-                decimals: 9,
             })
 
             try {
@@ -178,10 +179,10 @@ describe('genesis swap and bonding curve commands', () => {
         it('rejects invalid --creatorWallet on register', async () => {
             const tmpFile = path.join(os.tmpdir(), `test-reg-cw-${process.pid}.json`)
             fs.writeFileSync(tmpFile, JSON.stringify({
-                wallet: 'TESTfCYwTPxME2cAnPcKvvF5xdPah3PY7naYQEP2kkx',
-                token: { name: 'Test', symbol: 'TST', image: 'https://gateway.irys.xyz/abc' },
-                launchType: 'bondingCurve',
                 launch: {},
+                launchType: 'bondingCurve',
+                token: { image: 'https://gateway.irys.xyz/abc', name: 'Test', symbol: 'TST' },
+                wallet: 'TESTfCYwTPxME2cAnPcKvvF5xdPah3PY7naYQEP2kkx',
             }))
 
             try {
@@ -203,10 +204,10 @@ describe('genesis swap and bonding curve commands', () => {
         it('accepts valid --creatorWallet on register (reaches API call)', async () => {
             const tmpFile = path.join(os.tmpdir(), `test-reg-cw-ok-${process.pid}.json`)
             fs.writeFileSync(tmpFile, JSON.stringify({
-                wallet: 'TESTfCYwTPxME2cAnPcKvvF5xdPah3PY7naYQEP2kkx',
-                token: { name: 'Test', symbol: 'TST', image: 'https://gateway.irys.xyz/abc' },
-                launchType: 'bondingCurve',
                 launch: {},
+                launchType: 'bondingCurve',
+                token: { image: 'https://gateway.irys.xyz/abc', name: 'Test', symbol: 'TST' },
+                wallet: 'TESTfCYwTPxME2cAnPcKvvF5xdPah3PY7naYQEP2kkx',
             }))
 
             try {

--- a/test/commands/genesis/genesis.swap.test.ts
+++ b/test/commands/genesis/genesis.swap.test.ts
@@ -28,49 +28,31 @@ describe('genesis swap and bonding curve commands', () => {
             }
         })
 
-        it('fails when --direction is missing for swap (no --info)', async () => {
+        it('fails when neither --buyAmount nor --sellAmount is provided', async () => {
             try {
                 await runCli([
                     'genesis', 'swap',
                     '11111111111111111111111111111111',
-                    '--amount', '100000000',
-                ])
-                expect.fail('Should have thrown an error for missing direction')
-            } catch (error) {
-                const msg = (error as Error).message
-                expect(msg).to.contain('--direction is required')
-            }
-        })
-
-        it('fails when --amount is missing for swap (no --info)', async () => {
-            try {
-                await runCli([
-                    'genesis', 'swap',
-                    '11111111111111111111111111111111',
-                    '--direction', 'buy',
                 ])
                 expect.fail('Should have thrown an error for missing amount')
             } catch (error) {
                 const msg = (error as Error).message
-                expect(msg).to.contain('--amount is required')
+                expect(msg).to.contain('--buyAmount or --sellAmount is required')
             }
         })
 
-        it('rejects invalid direction value', async () => {
+        it('fails when both --buyAmount and --sellAmount are provided', async () => {
             try {
                 await runCli([
                     'genesis', 'swap',
                     '11111111111111111111111111111111',
-                    '--direction', 'invalid' as any,
-                    '--amount', '100000000',
+                    '--buyAmount', '100000000',
+                    '--sellAmount', '500000000',
                 ])
-                expect.fail('Should have thrown an error for invalid direction')
+                expect.fail('Should have thrown an error for both amounts')
             } catch (error) {
                 const msg = (error as Error).message
-                expect(msg).to.satisfy(
-                    (m: string) => m.includes('Expected') || m.includes('buy') || m.includes('invalid'),
-                    'Expected error about invalid direction'
-                )
+                expect(msg).to.contain('Cannot specify both')
             }
         })
 
@@ -96,8 +78,7 @@ describe('genesis swap and bonding curve commands', () => {
                 await runCli([
                     'genesis', 'swap',
                     '11111111111111111111111111111111',
-                    '--direction', 'buy',
-                    '--amount', '100000000',
+                    '--buyAmount', '100000000',
                 ])
                 expect.fail('Should have thrown for non-existent account')
             } catch (error) {

--- a/test/commands/genesis/genesis.swap.test.ts
+++ b/test/commands/genesis/genesis.swap.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { runCli } from '../../runCli'
-import { stripAnsi, createGenesisAccount } from './genesishelpers'
+import { createGenesisAccount } from './genesishelpers'
 
 describe('genesis swap and bonding curve commands', () => {
 

--- a/test/commands/genesis/genesis.swap.test.ts
+++ b/test/commands/genesis/genesis.swap.test.ts
@@ -1,0 +1,249 @@
+import { expect } from 'chai'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { runCli } from '../../runCli'
+import { stripAnsi, createGenesisAccount } from './genesishelpers'
+
+describe('genesis swap and bonding curve commands', () => {
+
+    before(async () => {
+        await runCli(['toolbox', 'sol', 'airdrop', '100', 'TESTfCYwTPxME2cAnPcKvvF5xdPah3PY7naYQEP2kkx'])
+        await new Promise(resolve => setTimeout(resolve, 5000))
+        await runCli(['toolbox', 'sol', 'wrap', '50'])
+    })
+
+    describe('genesis swap flag validation', () => {
+
+        it('fails when genesis account is missing', async () => {
+            try {
+                await runCli(['genesis', 'swap'])
+                expect.fail('Should have thrown an error for missing argument')
+            } catch (error) {
+                const msg = (error as Error).message
+                expect(msg).to.satisfy(
+                    (m: string) => m.includes('Missing') || m.includes('genesis') || m.includes('GENESIS'),
+                    'Expected error about missing genesis argument'
+                )
+            }
+        })
+
+        it('fails when --direction is missing for swap (no --info)', async () => {
+            try {
+                await runCli([
+                    'genesis', 'swap',
+                    '11111111111111111111111111111111',
+                    '--amount', '100000000',
+                ])
+                expect.fail('Should have thrown an error for missing direction')
+            } catch (error) {
+                const msg = (error as Error).message
+                expect(msg).to.contain('--direction is required')
+            }
+        })
+
+        it('fails when --amount is missing for swap (no --info)', async () => {
+            try {
+                await runCli([
+                    'genesis', 'swap',
+                    '11111111111111111111111111111111',
+                    '--direction', 'buy',
+                ])
+                expect.fail('Should have thrown an error for missing amount')
+            } catch (error) {
+                const msg = (error as Error).message
+                expect(msg).to.contain('--amount is required')
+            }
+        })
+
+        it('rejects invalid direction value', async () => {
+            try {
+                await runCli([
+                    'genesis', 'swap',
+                    '11111111111111111111111111111111',
+                    '--direction', 'invalid' as any,
+                    '--amount', '100000000',
+                ])
+                expect.fail('Should have thrown an error for invalid direction')
+            } catch (error) {
+                const msg = (error as Error).message
+                expect(msg).to.satisfy(
+                    (m: string) => m.includes('Expected') || m.includes('buy') || m.includes('invalid'),
+                    'Expected error about invalid direction'
+                )
+            }
+        })
+
+        it('--info mode does not require --direction or --amount', async () => {
+            // Should get past flag parsing and fail on account lookup
+            try {
+                await runCli([
+                    'genesis', 'swap',
+                    '11111111111111111111111111111111',
+                    '--info',
+                ])
+                expect.fail('Should have thrown an error for non-existent account')
+            } catch (error) {
+                const msg = (error as Error).message
+                // Should fail at account fetch, not flag validation
+                expect(msg).to.not.contain('--direction is required')
+                expect(msg).to.not.contain('--amount is required')
+            }
+        })
+
+        it('swap fails on non-existent genesis account', async () => {
+            try {
+                await runCli([
+                    'genesis', 'swap',
+                    '11111111111111111111111111111111',
+                    '--direction', 'buy',
+                    '--amount', '100000000',
+                ])
+                expect.fail('Should have thrown for non-existent account')
+            } catch (error) {
+                const msg = (error as Error).message
+                expect(msg).to.satisfy(
+                    (m: string) => m.includes('Failed to swap') || m.includes('not found') || m.includes('UnexpectedAccountError'),
+                    'Expected error about failed swap or missing account'
+                )
+            }
+        })
+
+        it('swap --info fails on non-existent genesis account', async () => {
+            try {
+                await runCli([
+                    'genesis', 'swap',
+                    '11111111111111111111111111111111',
+                    '--info',
+                ])
+                expect.fail('Should have thrown for non-existent account')
+            } catch (error) {
+                const msg = (error as Error).message
+                expect(msg).to.satisfy(
+                    (m: string) => m.includes('Failed to fetch curve info') || m.includes('not found') || m.includes('UnexpectedAccountError'),
+                    'Expected error about failed info or missing account'
+                )
+            }
+        })
+    })
+
+    describe('genesis bucket fetch --type bonding-curve', () => {
+
+        it('reports not found for non-existent bonding curve bucket', async () => {
+            const result = await createGenesisAccount({
+                name: 'BC Fetch Test',
+                symbol: 'BFT',
+                totalSupply: '1000000000',
+                decimals: 9,
+            })
+
+            try {
+                await runCli([
+                    'genesis', 'bucket', 'fetch',
+                    result.genesisAddress,
+                    '--type', 'bonding-curve',
+                    '--bucketIndex', '0',
+                ])
+                expect.fail('Should have thrown for missing bonding curve bucket')
+            } catch (error) {
+                const msg = (error as Error).message
+                expect(msg).to.contain('Bonding curve bucket not found')
+            }
+        })
+    })
+
+    describe('genesis launch create with registration flags', () => {
+
+        it('rejects invalid --creatorWallet', async () => {
+            try {
+                await runCli([
+                    'genesis', 'launch', 'create',
+                    '--launchType', 'bonding-curve',
+                    '--name', 'Test',
+                    '--symbol', 'TST',
+                    '--image', 'https://gateway.irys.xyz/abc123',
+                    '--creatorWallet', 'not-a-valid-key',
+                ])
+                expect.fail('Should have thrown for invalid creatorWallet')
+            } catch (error) {
+                const msg = (error as Error).message
+                expect(msg).to.contain('--creatorWallet must be a valid public key')
+            }
+        })
+
+        it('accepts valid --creatorWallet and --twitterVerificationToken (reaches API call)', async () => {
+            try {
+                await runCli([
+                    'genesis', 'launch', 'create',
+                    '--launchType', 'bonding-curve',
+                    '--name', 'Test',
+                    '--symbol', 'TST',
+                    '--image', 'https://gateway.irys.xyz/abc123',
+                    '--creatorWallet', 'TESTfCYwTPxME2cAnPcKvvF5xdPah3PY7naYQEP2kkx',
+                    '--twitterVerificationToken', 'test-token-123',
+                ])
+                expect.fail('Should have thrown an API error (API not available on localnet)')
+            } catch (error) {
+                // Should get past flag validation and fail at API call
+                const msg = (error as Error).message
+                expect(msg).to.contain('Failed')
+                expect(msg).to.not.contain('--creatorWallet must be a valid public key')
+            }
+        })
+    })
+
+    describe('genesis launch register with registration flags', () => {
+
+        it('rejects invalid --creatorWallet on register', async () => {
+            const tmpFile = path.join(os.tmpdir(), `test-reg-cw-${process.pid}.json`)
+            fs.writeFileSync(tmpFile, JSON.stringify({
+                wallet: 'TESTfCYwTPxME2cAnPcKvvF5xdPah3PY7naYQEP2kkx',
+                token: { name: 'Test', symbol: 'TST', image: 'https://gateway.irys.xyz/abc' },
+                launchType: 'bondingCurve',
+                launch: {},
+            }))
+
+            try {
+                await runCli([
+                    'genesis', 'launch', 'register',
+                    '11111111111111111111111111111111',
+                    '--launchConfig', tmpFile,
+                    '--creatorWallet', 'not-a-valid-key',
+                ])
+                expect.fail('Should have thrown for invalid creatorWallet')
+            } catch (error) {
+                const msg = (error as Error).message
+                expect(msg).to.contain('--creatorWallet must be a valid public key')
+            } finally {
+                fs.unlinkSync(tmpFile)
+            }
+        })
+
+        it('accepts valid --creatorWallet on register (reaches API call)', async () => {
+            const tmpFile = path.join(os.tmpdir(), `test-reg-cw-ok-${process.pid}.json`)
+            fs.writeFileSync(tmpFile, JSON.stringify({
+                wallet: 'TESTfCYwTPxME2cAnPcKvvF5xdPah3PY7naYQEP2kkx',
+                token: { name: 'Test', symbol: 'TST', image: 'https://gateway.irys.xyz/abc' },
+                launchType: 'bondingCurve',
+                launch: {},
+            }))
+
+            try {
+                await runCli([
+                    'genesis', 'launch', 'register',
+                    '11111111111111111111111111111111',
+                    '--launchConfig', tmpFile,
+                    '--creatorWallet', 'TESTfCYwTPxME2cAnPcKvvF5xdPah3PY7naYQEP2kkx',
+                    '--twitterVerificationToken', 'test-token-123',
+                ])
+                expect.fail('Should have thrown an API error')
+            } catch (error) {
+                const msg = (error as Error).message
+                expect(msg).to.contain('Failed')
+                expect(msg).to.not.contain('--creatorWallet must be a valid public key')
+            } finally {
+                fs.unlinkSync(tmpFile)
+            }
+        })
+    })
+})


### PR DESCRIPTION
## Summary
- New `genesis swap` command for buying/selling on bonding curves with `--buyAmount` / `--sellAmount`, auto-wrapping SOL to WSOL when needed
- `genesis swap --info` for curve status, price quotes, and fee breakdown without transacting
- `genesis bucket fetch` now auto-detects bucket type (no `--type` required), shows all buckets at an index when multiple exist, and supports `--type bonding-curve`
- `--creatorWallet` and `--twitterVerificationToken` flags on `genesis launch create` and `genesis launch register`
- Updated genesis SDK from v0.32.1 to v0.34.0 for devnet API compatibility (new bonding curve constants)

## Test plan
- [x] 11 new mocha tests (flag validation, error paths, bucket fetch, registration flags)
- [x] All 38 existing genesis tests pass
- [x] Manual devnet testing: bucket fetch auto-detect, swap buy/sell, swap info with quotes, launch create with registration flags, validation errors
- [x] Auto-wrap SOL verified on devnet (works with no WSOL ATA, partial balance, and sufficient balance)
- [x] Multi-bucket auto-detect verified on localnet (launchpool + presale + unlocked at same index)