### PR TITLE
Support AgentIdentityV2 with agent token in fetch command

### DIFF
--- a/src/commands/agents/fetch.ts
+++ b/src/commands/agents/fetch.ts
@@ -5,10 +5,9 @@ import { publicKey } from '@metaplex-foundation/umi'
 import { fetchAssetV1, findAssetSignerPda } from '@metaplex-foundation/mpl-core'
 import { BaseCommand } from '../../BaseCommand.js'
 import {
-  fetchAgentIdentityV2,
   findAgentIdentityV2Pda,
-  Key,
   safeFetchAgentIdentityV1,
+  safeFetchAgentIdentityV2,
 } from '@metaplex-foundation/mpl-agent-registry/dist/src/generated/identity/index.js'
 
 export default class AgentsFetch extends BaseCommand<typeof AgentsFetch> {
@@ -37,24 +36,33 @@ export default class AgentsFetch extends BaseCommand<typeof AgentsFetch> {
 
     // Derive and fetch the agent identity PDA. V1 and V2 share the same PDA
     // seeds; V2 is the upgraded format that carries the canonical agent token.
+    // Try V2 first and fall back to V1 if deserialization fails (e.g. the
+    // account has not been upgraded yet).
     const [identityPda] = findAgentIdentityV2Pda(umi, { asset: assetPk })
-    const identity = await safeFetchAgentIdentityV1(umi, identityPda)
 
-    if (!identity) {
-      this.log('No agent identity found for this asset. The asset may not be registered.')
-      return { registered: false, asset: args.asset }
-    }
-
-    // If the on-chain account has been upgraded to V2, read the canonical
-    // agent token from the mpl-agent-registry.
     let hasAgentToken = false
     let agentToken: string | null = null
-    if (identity.key === Key.AgentIdentityV2) {
-      const identityV2 = await fetchAgentIdentityV2(umi, identityPda)
-      hasAgentToken = identityV2.agentToken.__option === 'Some'
-      if (identityV2.agentToken.__option === 'Some') {
-        agentToken = identityV2.agentToken.value.toString()
+    let identityExists = false
+
+    try {
+      const identityV2 = await safeFetchAgentIdentityV2(umi, identityPda)
+      if (identityV2) {
+        identityExists = true
+        hasAgentToken = identityV2.agentToken.__option === 'Some'
+        if (identityV2.agentToken.__option === 'Some') {
+          agentToken = identityV2.agentToken.value.toString()
+        }
       }
+    } catch {
+      const identityV1 = await safeFetchAgentIdentityV1(umi, identityPda)
+      if (identityV1) {
+        identityExists = true
+      }
+    }
+
+    if (!identityExists) {
+      this.log('No agent identity found for this asset. The asset may not be registered.')
+      return { registered: false, asset: args.asset }
     }
 
     // Derive the Asset Signer PDA (agent wallet)

--- a/src/commands/agents/fetch.ts
+++ b/src/commands/agents/fetch.ts
@@ -4,7 +4,12 @@ import util from 'node:util'
 import { publicKey } from '@metaplex-foundation/umi'
 import { fetchAssetV1, findAssetSignerPda } from '@metaplex-foundation/mpl-core'
 import { BaseCommand } from '../../BaseCommand.js'
-import { findAgentIdentityV1Pda, safeFetchAgentIdentityV1 } from '@metaplex-foundation/mpl-agent-registry/dist/src/generated/identity/index.js'
+import {
+  fetchAgentIdentityV2,
+  findAgentIdentityV2Pda,
+  Key,
+  safeFetchAgentIdentityV1,
+} from '@metaplex-foundation/mpl-agent-registry/dist/src/generated/identity/index.js'
 
 export default class AgentsFetch extends BaseCommand<typeof AgentsFetch> {
   static override description = `Fetch and display agent identity data for a registered Core asset.
@@ -30,13 +35,26 @@ export default class AgentsFetch extends BaseCommand<typeof AgentsFetch> {
     // Fetch the Core asset
     const asset = await fetchAssetV1(umi, assetPk)
 
-    // Derive and fetch the agent identity PDA
-    const [identityPda] = findAgentIdentityV1Pda(umi, { asset: assetPk })
+    // Derive and fetch the agent identity PDA. V1 and V2 share the same PDA
+    // seeds; V2 is the upgraded format that carries the canonical agent token.
+    const [identityPda] = findAgentIdentityV2Pda(umi, { asset: assetPk })
     const identity = await safeFetchAgentIdentityV1(umi, identityPda)
 
     if (!identity) {
       this.log('No agent identity found for this asset. The asset may not be registered.')
       return { registered: false, asset: args.asset }
+    }
+
+    // If the on-chain account has been upgraded to V2, read the canonical
+    // agent token from the mpl-agent-registry.
+    let hasAgentToken = false
+    let agentToken: string | null = null
+    if (identity.key === Key.AgentIdentityV2) {
+      const identityV2 = await fetchAgentIdentityV2(umi, identityPda)
+      hasAgentToken = identityV2.agentToken.__option === 'Some'
+      if (identityV2.agentToken.__option === 'Some') {
+        agentToken = identityV2.agentToken.value.toString()
+      }
     }
 
     // Derive the Asset Signer PDA (agent wallet)
@@ -53,6 +71,8 @@ export default class AgentsFetch extends BaseCommand<typeof AgentsFetch> {
       wallet: walletPda.toString(),
       registrationUri: agentPlugin?.uri ?? null,
       lifecycleChecks: agentPlugin?.lifecycleChecks ?? null,
+      hasAgentToken,
+      agentToken,
     }
 
     this.log(util.inspect(result, false, null, true))


### PR DESCRIPTION
## Summary
Updated the agents fetch command to support the new AgentIdentityV2 account format, which includes an optional agent token field. The command now detects when an account has been upgraded to V2 and retrieves the canonical agent token from the mpl-agent-registry.

## Key Changes
- Updated imports to include `fetchAgentIdentityV2`, `findAgentIdentityV2Pda`, and `Key` from mpl-agent-registry
- Changed PDA derivation to use `findAgentIdentityV2Pda` (V1 and V2 share the same PDA seeds)
- Added logic to detect V2 accounts by checking the `identity.key` field
- When V2 is detected, fetch the full `AgentIdentityV2` account to access the agent token
- Added `hasAgentToken` and `agentToken` fields to the output result
- Included clarifying comments about V1/V2 compatibility and the upgrade path

## Implementation Details
- The agent token is stored as an `Option` type in V2, so the code checks `__option === 'Some'` before accessing the value
- The agent token is converted to a string for display
- Backward compatibility is maintained by continuing to support V1 accounts (which will have `hasAgentToken: false`)

https://claude.ai/code/session_01XiX5mDmuJ1ihMp484EF4q9