### PR TITLE
fix template feature

### DIFF
--- a/src/commands/toolbox/template/program.ts
+++ b/src/commands/toolbox/template/program.ts
@@ -41,15 +41,11 @@ export default class ToolboxProgramTemplate extends Command {
 
         try {
             const { stdout, stderr } = await execAsync(`git clone ${templates[template as keyof typeof templates]}`)
-            
+
             if (stdout) {
                 this.log(stdout)
             }
-            
-            if (stderr) {
-                this.error(stderr)
-            }
-            
+
             this.log(`Template '${template}' cloned successfully`)
         } catch (error) {
             this.error(`Failed to clone template '${template}': ${error instanceof Error ? error.message : 'Unknown error'}`)

--- a/src/commands/toolbox/template/website.ts
+++ b/src/commands/toolbox/template/website.ts
@@ -16,7 +16,7 @@ export default class ToolboxWebsiteTemplate extends Command {
     static override description = 'Download a MPLX website template'
 
     static override flags = {
-        '--template': Flags.string({
+        template: Flags.string({
             description: 'The template to download',
             required: false,
             options: Object.keys(templates)
@@ -39,15 +39,11 @@ export default class ToolboxWebsiteTemplate extends Command {
 
         try {
             const { stdout, stderr } = await execAsync(`git clone ${templates[template as keyof typeof templates]}`)
-            
+
             if (stdout) {
                 this.log(stdout)
             }
-            
-            if (stderr) {
-                this.error(stderr)
-            }
-            
+
             this.log(`Template '${template}' cloned successfully`)
         } catch (error) {
             this.error(`Failed to clone template '${template}': ${error instanceof Error ? error.message : 'Unknown error'}`)


### PR DESCRIPTION
  1. template/website.ts + template/program.ts: Removed the if (stderr) this.error(stderr) check. git clone writes progress to stderr, which was incorrectly treated as a failure. Actual clone failures are caught by the catch block (since execAsync rejects on non-zero exit code).           
  2. template/website.ts: Fixed the malformed flag key '--template' to template so the CLI renders  --template instead of ----template.                                                               