### PR TITLE
Fix cm wizard collection plugins

### DIFF
--- a/src/commands/cm/create.ts
+++ b/src/commands/cm/create.ts
@@ -5,7 +5,7 @@ import {
 } from '@metaplex-foundation/mpl-core-candy-machine'
 import { generateSigner, publicKey, Umi } from '@metaplex-foundation/umi'
 import { Args, Flags } from '@oclif/core'
-import { input, select } from '@inquirer/prompts'
+import { confirm, input, select } from '@inquirer/prompts'
 import fs from 'node:fs'
 import ora from 'ora'
 import path from 'node:path'
@@ -20,6 +20,9 @@ import createCmTemplateFolder from '../../lib/cm/createCmTemplateFolder.js'
 import insertItems from '../../lib/cm/insertItems.js'
 import jsonGuardParser from '../../lib/cm/jsonGuardParser.js'
 import createCandyMachinePrompt from '../../lib/cm/prompts/createCandyMachineWizardPrompt.js'
+import { Plugin, PluginData } from '../../lib/types/pluginData.js'
+import pluginConfigurator, { mapPluginDataToArray } from '../../prompts/pluginInquirer.js'
+import { PluginFilterType, pluginSelector, validatePluginCompatibility } from '../../prompts/pluginSelector.js'
 import { CandyMachineAssetCache, CandyMachineAssetCacheItem, CandyMachineConfig } from '../../lib/cm/types.js'
 import uploadCandyMachineItems from '../../lib/cm/uploadItems.js'
 import { validateCacheUploads, ValidateCacheUploadsOptions } from '../../lib/cm/validateCacheUploads.js'
@@ -402,12 +405,30 @@ export default class CmCreate extends TransactionCommand<typeof CmCreate> {
         collectionJson.uri = jsonUri[0].uri
         collectionJsonSpinner.succeed('Collection metadata uploaded')
 
+        // Prompt for collection plugins
+        let pluginData: PluginData | undefined
+        const wantsPlugins = await confirm({
+            message: 'Do you want to add plugins (e.g. royalties) to this collection?',
+        })
+
+        if (wantsPlugins) {
+            const selectedPlugins = await pluginSelector({ filter: PluginFilterType.Collection })
+            if (selectedPlugins && (selectedPlugins as Plugin[]).length > 0) {
+                const incompatibleError = validatePluginCompatibility(selectedPlugins as Plugin[])
+                if (incompatibleError) {
+                    throw new Error(incompatibleError)
+                }
+                pluginData = await pluginConfigurator(selectedPlugins as Plugin[])
+            }
+        }
+
         // Collection creation onchain
         const collectionCreationSpinner = ora('🏭 Creating collection onchain...').start()
         const collectionTx = createCollection(umi, {
             collection,
             name: collectionJson.name,
             uri: collectionJson.uri,
+            plugins: pluginData ? mapPluginDataToArray(pluginData) : undefined,
         })
         await umiSendAndConfirmTransaction(umi, collectionTx, { commitment: 'finalized' })
 

--- a/src/lib/cm/jsonGuardParser.ts
+++ b/src/lib/cm/jsonGuardParser.ts
@@ -1,5 +1,5 @@
 import { DefaultGuardSet } from "@metaplex-foundation/mpl-core-candy-machine"
-import { publicKey, sol, some } from "@metaplex-foundation/umi"
+import { lamports as createLamports, publicKey, some } from "@metaplex-foundation/umi"
 import { 
     CandyMachineConfig, 
     RawGuardConfig, 
@@ -393,7 +393,7 @@ const parseGuard = (guardName: string, guardValue: unknown): Partial<DefaultGuar
             }
             const validatedGuard = guardValue as RawBotTax;
             parsedGuard.botTax = some({
-                lamports: sol(Number(validatedGuard.lamports) / 10 ** 9),
+                lamports: createLamports(validatedGuard.lamports),
                 lastInstruction: validatedGuard.lastInstruction
             });
             break;
@@ -418,7 +418,7 @@ const parseGuard = (guardName: string, guardValue: unknown): Partial<DefaultGuar
             }
             const validatedGuard = guardValue as RawFreezeSolPayment;
             parsedGuard.freezeSolPayment = some({
-                lamports: sol(Number(validatedGuard.lamports) / 10 ** 9),
+                lamports: createLamports(validatedGuard.lamports),
                 destination: publicKey(validatedGuard.destination),
                 period: BigInt(validatedGuard.period)
             });
@@ -510,7 +510,7 @@ const parseGuard = (guardName: string, guardValue: unknown): Partial<DefaultGuar
             }
             const validatedGuard = guardValue as RawSolFixedFee;
             parsedGuard.solFixedFee = some({
-                lamports: sol(Number(validatedGuard.lamports) / 10 ** 9),
+                lamports: createLamports(validatedGuard.lamports),
                 destination: publicKey(validatedGuard.destination)
             });
             break;
@@ -521,7 +521,7 @@ const parseGuard = (guardName: string, guardValue: unknown): Partial<DefaultGuar
             }
             const validatedGuard = guardValue as RawSolPayment;
             parsedGuard.solPayment = some({
-                lamports: sol(Number(validatedGuard.lamports) / 10 ** 9),
+                lamports: createLamports(validatedGuard.lamports),
                 destination: publicKey(validatedGuard.destination)
             });
             break;

--- a/src/prompts/pluginInquirer.ts
+++ b/src/prompts/pluginInquirer.ts
@@ -54,6 +54,9 @@ const pluginConfigurator = async (plugins: Array<Plugin>): Promise<PluginData> =
         numberOfCreators = parseInt(creatorsStr)
 
         for (let index = 0; index < numberOfCreators; index++) {
+          const isLastCreator = index === numberOfCreators - 1
+          const remaining = 100 - totalRoyalty
+
           console.log(`${terminalColors.FgCyan}Configuring Creator ${index + 1} of ${numberOfCreators}`)
           const address = await input({
             message: `Creator ${index + 1} Address?`,
@@ -63,22 +66,25 @@ const pluginConfigurator = async (plugins: Array<Plugin>): Promise<PluginData> =
             },
           })
 
-          const percentageStr = await input({
-            message: `Creator ${index + 1} Percentage? (remaining: ${100 - totalRoyalty}%)`,
-            validate: (value) => {
-              const num = parseInt(value)
-              if (isNaN(num) || num <= 0) return 'Value must be greater than 0'
-              if (num > (100 - totalRoyalty)) return `Value must not exceed remaining percentage (${100 - totalRoyalty}%)`
-              return true
-            },
-          })
-          const percentage = parseInt(percentageStr)
+          let percentage: number
+          if (isLastCreator) {
+            percentage = remaining
+            console.log(`Creator ${index + 1} Percentage: ${percentage}% (auto-assigned remaining)`)
+          } else {
+            const percentageStr = await input({
+              message: `Creator ${index + 1} Percentage? (remaining: ${remaining}%)`,
+              validate: (value) => {
+                const num = parseInt(value)
+                if (isNaN(num) || num <= 0) return 'Value must be greater than 0'
+                if (num >= remaining) return `Value must be less than remaining percentage (${remaining}%) — need to leave room for ${numberOfCreators - index - 1} more creator(s)`
+                return true
+              },
+            })
+            percentage = parseInt(percentageStr)
+          }
+
           creators.push({address: publicKey(address), percentage})
           totalRoyalty += percentage
-        }
-
-        if (totalRoyalty !== 100) {
-          throw new Error('Total royalty percentage must equal 100%')
         }
 
         pluginData.royalties = {


### PR DESCRIPTION
Fix collection plugins and guard parsing in CM wizard                                                                              
                                                                                                                                     
 - Add plugin prompt (royalties, etc.) when creating a collection through cm create --wizard — previously skipped entirely          
 - Fix BigInt crash when parsing small lamport values in guard config (sol(1/10**9) → lamports(1))                                  
 - Auto-assign remaining royalty percentage to last creator instead of crashing