### PR TITLE
Report failed item insertions instead of showing false success

### DIFF
--- a/src/commands/cm/create.ts
+++ b/src/commands/cm/create.ts
@@ -13,6 +13,7 @@ import { TransactionCommand } from '../../TransactionCommand.js'
 import {
     getConfigLineSettings,
     readCmConfig,
+    summarizeAssetCache,
     validateCmConfig,
     writeCmConfig
 } from '../../lib/cm/cm-utils.js'
@@ -227,13 +228,11 @@ export default class CmCreate extends TransactionCommand<typeof CmCreate> {
         fs.writeFileSync(path.join(candyMachineDir, 'asset-cache.json'), JSON.stringify(insertItemsRes.assetCache, null, 2))
 
         // Check for failed insertions
-        const totalItems = Object.keys(insertItemsRes.assetCache.assetItems).length
-        const loadedItems = Object.values(insertItemsRes.assetCache.assetItems).filter(item => item.loaded).length
-        const failedItems = totalItems - loadedItems
+        const { totalItems, failedItems } = summarizeAssetCache(insertItemsRes.assetCache)
 
         if (failedItems > 0) {
             this.log(`\n⚠️  ${failedItems} of ${totalItems} items failed to insert.`)
-            this.log(`Run 'mplx cm insert${candyMachineDir !== process.cwd() ? ` ${path.basename(candyMachineDir)}` : ''}' to retry failed items.`)
+            this.log(`Run 'mplx cm insert${candyMachineDir !== process.cwd() ? ` ${path.basename(candyMachineDir)}` : ''}' again to retry failed items.`)
         }
 
         // Wizard completion message and summary (moved here after all processing is complete)

--- a/src/commands/cm/create.ts
+++ b/src/commands/cm/create.ts
@@ -226,6 +226,16 @@ export default class CmCreate extends TransactionCommand<typeof CmCreate> {
         const insertItemsRes = await insertItems(umi, candyMachineConfig, uploadResult.assetCache)
         fs.writeFileSync(path.join(candyMachineDir, 'asset-cache.json'), JSON.stringify(insertItemsRes.assetCache, null, 2))
 
+        // Check for failed insertions
+        const totalItems = Object.keys(insertItemsRes.assetCache.assetItems).length
+        const loadedItems = Object.values(insertItemsRes.assetCache.assetItems).filter(item => item.loaded).length
+        const failedItems = totalItems - loadedItems
+
+        if (failedItems > 0) {
+            this.log(`\n⚠️  ${failedItems} of ${totalItems} items failed to insert.`)
+            this.log(`Run 'mplx cm insert${candyMachineDir !== process.cwd() ? ` ${path.basename(candyMachineDir)}` : ''}' to retry failed items.`)
+        }
+
         // Wizard completion message and summary (moved here after all processing is complete)
         this.log('\n🎉 Wizard complete! Here is a summary of your setup:')
         this.log(`- Directory: ${useCurrentDirectory ? 'Current directory' : path.basename(candyMachineDir)}`)

--- a/src/commands/cm/insert.ts
+++ b/src/commands/cm/insert.ts
@@ -51,12 +51,22 @@ export default class CmInsert extends TransactionCommand<typeof CmInsert> {
 
             writeAssetCache(res.assetCache, args.directory);
 
-            this.logSuccess(`Asset cache updated successfully`);
+            const totalItems = Object.keys(res.assetCache.assetItems).length
+            const loadedItems = Object.values(res.assetCache.assetItems).filter(item => item.loaded).length
+            const failedItems = totalItems - loadedItems
 
-            const itemsInserted = Object.keys(res.assetCache.assetItems).length
+            if (failedItems > 0) {
+                this.log(`\n⚠️  ${failedItems} of ${totalItems} items failed to insert.`)
+                this.log(`Run 'mplx cm insert${args.directory ? ` ${args.directory}` : ''}' again to retry failed items.`)
+            } else {
+                this.logSuccess(`All ${totalItems} items inserted successfully`);
+            }
+
             return {
                 candyMachineId: config.candyMachineId?.toString(),
-                itemsInserted,
+                totalItems,
+                itemsInserted: loadedItems,
+                itemsFailed: failedItems,
             }
         } catch (error) {
             this.error(`Insert failed: ${error instanceof Error ? error.message : String(error)}`);

--- a/src/commands/cm/insert.ts
+++ b/src/commands/cm/insert.ts
@@ -1,7 +1,7 @@
 import { Args } from '@oclif/core'
 import { TransactionCommand } from '../../TransactionCommand.js'
 import insertItems from '../../lib/cm/insertItems.js'
-import { readCmConfig, readAssetCache, writeAssetCache, getCmPaths } from '../../lib/cm/cm-utils.js'
+import { readCmConfig, readAssetCache, writeAssetCache, getCmPaths, summarizeAssetCache } from '../../lib/cm/cm-utils.js'
 import fs from 'node:fs'
 
 export default class CmInsert extends TransactionCommand<typeof CmInsert> {
@@ -51,13 +51,12 @@ export default class CmInsert extends TransactionCommand<typeof CmInsert> {
 
             writeAssetCache(res.assetCache, args.directory);
 
-            const totalItems = Object.keys(res.assetCache.assetItems).length
-            const loadedItems = Object.values(res.assetCache.assetItems).filter(item => item.loaded).length
-            const failedItems = totalItems - loadedItems
+            const { totalItems, loadedItems, failedItems } = summarizeAssetCache(res.assetCache)
 
             if (failedItems > 0) {
                 this.log(`\n⚠️  ${failedItems} of ${totalItems} items failed to insert.`)
                 this.log(`Run 'mplx cm insert${args.directory ? ` ${args.directory}` : ''}' again to retry failed items.`)
+                process.exitCode = 1
             } else {
                 this.logSuccess(`All ${totalItems} items inserted successfully`);
             }

--- a/src/lib/cm/cm-utils.ts
+++ b/src/lib/cm/cm-utils.ts
@@ -101,6 +101,14 @@ export const createInitialAssetCache = async (directory?: string): Promise<Candy
     return assetCache;
 };
 
+// Summarize the load state of an asset cache after an insert run
+export const summarizeAssetCache = (assetCache: CandyMachineAssetCache) => {
+    const totalItems = Object.keys(assetCache.assetItems).length;
+    const loadedItems = Object.values(assetCache.assetItems).filter(item => item.loaded).length;
+    const failedItems = totalItems - loadedItems;
+    return { totalItems, loadedItems, failedItems };
+};
+
 // Common validation utilities
 export const validateCmDirectory = (directory?: string): void => {
     const { assetsDir } = getCmPaths(directory);

--- a/test/commands/cm/cm.full.test.ts
+++ b/test/commands/cm/cm.full.test.ts
@@ -53,7 +53,7 @@ describe('cm full lifecycle commands', () => {
 
             // Assert the insert command succeeded
             expect(cmInsertCode).to.equal(0)
-            expect(cmInsertStdout).to.include('Asset cache updated successfully')
+            expect(cmInsertStdout).to.include('items inserted successfully')
             expect(cmInsertStderr).to.include('Processed')
             expect(cmInsertStderr).to.include('transactions')
 

--- a/test/commands/cm/cm.insert.test.ts
+++ b/test/commands/cm/cm.insert.test.ts
@@ -52,7 +52,8 @@ describe('cm insert commands', () => {
 
             // Assert the insert command succeeded
             expect(code).to.equal(0)
-            expect(stdout).to.include('Asset cache updated successfully')
+            expect(stdout).to.include('All 50 items inserted successfully')
+            expect(stdout).to.not.include('failed to insert')
             expect(stderr).to.include('Processed')
             expect(stderr).to.include('transactions')
 
@@ -72,6 +73,62 @@ describe('cm insert commands', () => {
             } catch (cleanupError) {
                 // console.error(`Cleanup failed for ${cmName}:`, cleanupError)
             }
+        }
+    })
+
+    it('reports warning when some items fail to insert', async () => {
+        const cmName = "testCmInsertWarning"
+
+        try {
+            const { collectionId } = await createCoreCollection()
+
+            await execAsync(`npm run create-test-cm -- --name=${cmName} --with-config --collection=${collectionId} --with-assets --uploaded --assets=5`)
+
+            // Create candy machine
+            const { code: cmCreateCode } = await runCli(["cm", "create", `./${cmName}`])
+            expect(cmCreateCode).to.equal(0)
+
+            // First insert — all items succeed
+            const { code: insertCode1 } = await runCli(["cm", "insert", `./${cmName}`])
+            expect(insertCode1).to.equal(0)
+
+            const cachePath = `./${cmName}/asset-cache.json`
+            const configPath = `./${cmName}/cm-config.json`
+            const cache = JSON.parse(fs.readFileSync(cachePath, 'utf-8'))
+            const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'))
+
+            // Reset 2 items to unloaded and point to an invalid candy machine
+            // so the retry transactions fail
+            cache.assetItems[0].loaded = false
+            cache.assetItems[1].loaded = false
+            fs.writeFileSync(cachePath, JSON.stringify(cache, null, 2))
+
+            const originalCmId = config.candyMachineId
+            config.candyMachineId = '11111111111111111111111111111111'
+            fs.writeFileSync(configPath, JSON.stringify(config, null, 2))
+
+            // Re-run insert — should fail to insert the 2 unloaded items
+            // and report a warning
+            let stdout = ''
+            try {
+                const result = await runCli(["cm", "insert", `./${cmName}`])
+                stdout = result.stdout
+            } catch (error) {
+                // The command may exit non-zero if transactions fail,
+                // but the output should still contain the warning
+                stdout = (error as Error).message || ''
+            }
+
+            expect(stdout).to.include('failed to insert')
+            expect(stdout).to.include('retry')
+
+            // Restore original config
+            config.candyMachineId = originalCmId
+            fs.writeFileSync(configPath, JSON.stringify(config, null, 2))
+        } finally {
+            try {
+                await execAsync(`rm -rf ./${cmName}`)
+            } catch { /* ignore */ }
         }
     })
 
@@ -113,7 +170,7 @@ describe('cm insert commands', () => {
             // Re-run insert — should only process the 3 unloaded items
             const { stdout, stderr, code: insertCode2 } = await runCli(["cm", "insert", `./${cmName}`])
             expect(insertCode2).to.equal(0)
-            expect(stdout).to.include('Asset cache updated successfully')
+            expect(stdout).to.include('items inserted successfully')
 
             // Verify at most 3 transactions (one per unloaded item, possibly packed into fewer)
             const resumeTxMatch = stderr.match(/Processed (\d+) transactions/)

--- a/test/commands/cm/cm.insert.test.ts
+++ b/test/commands/cm/cm.insert.test.ts
@@ -28,7 +28,7 @@ describe('cm insert commands', () => {
 
             // console.log('Creating test candy machine directory')
             // Await the directory creation
-            await execAsync(`npm run create-test-cm -- --name=${cmName} --with-config --collection=${collectionId} --with-assets --uploaded`)
+            await execAsync(`npm run create-test-cm -- --name=${cmName} --with-config --collection=${collectionId} --with-assets --uploaded --assets=50`)
 
             const { stdout: cmCreateStdout, stderr: cmCreateStderr, code: cmCreateCode } = await runCli(
                 ["cm", "create", `./${cmName}`]

--- a/test/runCli.ts
+++ b/test/runCli.ts
@@ -33,7 +33,7 @@ export const runCli = (args: string[], stdin?: string[]): Promise<{ stdout: stri
 
         child.on('close', (code) => {
             if (code !== 0) {
-                reject(new Error(`Process failed with code ${code}\nstderr: ${stderr}`))
+                reject(new Error(`Process failed with code ${code}\nstdout: ${stdout}\nstderr: ${stderr}`))
             } else {
                 resolve({ stdout, stderr, code: 0 })
             }


### PR DESCRIPTION
cm insert and the wizard now count loaded vs failed items after insertion and warn when some items failed, with instructions to retry. Previously showed "Asset cache updated successfully" even when transactions failed (e.g. from RPC rate limiting).