### PR TITLE
chore: standardise agent terminology to agentMint / agentWallet

### DIFF
--- a/src/commands/agents/executive/delegate.ts
+++ b/src/commands/agents/executive/delegate.ts
@@ -19,13 +19,13 @@ export default class AgentsExecutiveDelegate extends TransactionCommand<typeof A
   `
 
   static override examples = [
-    '$ mplx agents executive delegate <agent-asset> --executive <executive-wallet>',
+    '$ mplx agents executive delegate <agentMint> --executive <executive-wallet>',
   ]
 
-  static override usage = 'agents executive delegate <agent-asset> --executive <executive-wallet>'
+  static override usage = 'agents executive delegate <agentMint> --executive <executive-wallet>'
 
   static override args = {
-    asset: Args.string({ description: 'The registered agent asset address to delegate', required: true }),
+    agentMint: Args.string({ description: 'The agent\'s Core asset address', required: true }),
   }
 
   static override flags = {
@@ -39,7 +39,7 @@ export default class AgentsExecutiveDelegate extends TransactionCommand<typeof A
     const { args, flags } = await this.parse(AgentsExecutiveDelegate)
     const { umi, explorer, chain } = this.context
 
-    const assetPk = publicKey(args.asset)
+    const assetPk = publicKey(args.agentMint)
 
     // Derive PDAs
     const [agentIdentity] = findAgentIdentityV1Pda(umi, { asset: assetPk })
@@ -60,14 +60,14 @@ export default class AgentsExecutiveDelegate extends TransactionCommand<typeof A
     const explorerUrl = generateExplorerUrl(explorer, chain, signature, 'transaction')
 
     this.log(`--------------------------------
-  Agent Asset: ${args.asset}
+  Agent Mint: ${args.agentMint}
   Executive Profile: ${executiveProfile.toString()}
   Signature: ${signature}
   Explorer: ${explorerUrl}
 --------------------------------`)
 
     return {
-      agentAsset: args.asset,
+      agentMint: args.agentMint,
       executiveWallet: flags.executive,
       executiveProfile: executiveProfile.toString(),
       signature,

--- a/src/commands/agents/executive/delegate.ts
+++ b/src/commands/agents/executive/delegate.ts
@@ -19,13 +19,13 @@ export default class AgentsExecutiveDelegate extends TransactionCommand<typeof A
   `
 
   static override examples = [
-    '$ mplx agents executive delegate <agentMint> --executive <executive-wallet>',
+    '$ mplx agents executive delegate <agentAsset> --executive <executive-wallet>',
   ]
 
-  static override usage = 'agents executive delegate <agentMint> --executive <executive-wallet>'
+  static override usage = 'agents executive delegate <agentAsset> --executive <executive-wallet>'
 
   static override args = {
-    agentMint: Args.string({ description: 'The agent\'s Core asset address', required: true }),
+    agentAsset: Args.string({ description: 'The agent\'s Core asset address', required: true }),
   }
 
   static override flags = {
@@ -39,7 +39,7 @@ export default class AgentsExecutiveDelegate extends TransactionCommand<typeof A
     const { args, flags } = await this.parse(AgentsExecutiveDelegate)
     const { umi, explorer, chain } = this.context
 
-    const assetPk = publicKey(args.agentMint)
+    const assetPk = publicKey(args.agentAsset)
 
     // Derive PDAs
     const [agentIdentity] = findAgentIdentityV1Pda(umi, { asset: assetPk })
@@ -60,14 +60,14 @@ export default class AgentsExecutiveDelegate extends TransactionCommand<typeof A
     const explorerUrl = generateExplorerUrl(explorer, chain, signature, 'transaction')
 
     this.log(`--------------------------------
-  Agent Mint: ${args.agentMint}
+  Agent Asset: ${args.agentAsset}
   Executive Profile: ${executiveProfile.toString()}
   Signature: ${signature}
   Explorer: ${explorerUrl}
 --------------------------------`)
 
     return {
-      agentMint: args.agentMint,
+      agentAsset: args.agentAsset,
       executiveWallet: flags.executive,
       executiveProfile: executiveProfile.toString(),
       signature,

--- a/src/commands/agents/executive/revoke.ts
+++ b/src/commands/agents/executive/revoke.ts
@@ -18,14 +18,14 @@ export default class AgentsExecutiveRevoke extends TransactionCommand<typeof Age
   `
 
   static override examples = [
-    '$ mplx agents executive revoke <agentMint>',
-    '$ mplx agents executive revoke <agentMint> --executive <executive-wallet>',
+    '$ mplx agents executive revoke <agentAsset>',
+    '$ mplx agents executive revoke <agentAsset> --executive <executive-wallet>',
   ]
 
-  static override usage = 'agents executive revoke <agentMint> [--executive <executive-wallet>]'
+  static override usage = 'agents executive revoke <agentAsset> [--executive <executive-wallet>]'
 
   static override args = {
-    agentMint: Args.string({ description: 'The agent\'s Core asset address', required: true }),
+    agentAsset: Args.string({ description: 'The agent\'s Core asset address', required: true }),
   }
 
   static override flags = {
@@ -41,7 +41,7 @@ export default class AgentsExecutiveRevoke extends TransactionCommand<typeof Age
     const { args, flags } = await this.parse(AgentsExecutiveRevoke)
     const { umi, explorer, chain, signer } = this.context
 
-    const assetPk = publicKey(args.agentMint)
+    const assetPk = publicKey(args.agentAsset)
     const executivePk = flags.executive ? publicKey(flags.executive) : signer.publicKey
 
     // Derive PDAs
@@ -72,14 +72,14 @@ export default class AgentsExecutiveRevoke extends TransactionCommand<typeof Age
     const explorerUrl = generateExplorerUrl(explorer, chain, signature, 'transaction')
 
     this.log(`--------------------------------
-  Agent Mint: ${args.agentMint}
+  Agent Asset: ${args.agentAsset}
   Executive Wallet: ${executivePk.toString()}
   Signature: ${signature}
   Explorer: ${explorerUrl}
 --------------------------------`)
 
     return {
-      agentMint: args.agentMint,
+      agentAsset: args.agentAsset,
       executiveWallet: executivePk.toString(),
       signature,
       explorer: explorerUrl,

--- a/src/commands/agents/executive/revoke.ts
+++ b/src/commands/agents/executive/revoke.ts
@@ -18,14 +18,14 @@ export default class AgentsExecutiveRevoke extends TransactionCommand<typeof Age
   `
 
   static override examples = [
-    '$ mplx agents executive revoke <agent-asset>',
-    '$ mplx agents executive revoke <agent-asset> --executive <executive-wallet>',
+    '$ mplx agents executive revoke <agentMint>',
+    '$ mplx agents executive revoke <agentMint> --executive <executive-wallet>',
   ]
 
-  static override usage = 'agents executive revoke <agent-asset> [--executive <executive-wallet>]'
+  static override usage = 'agents executive revoke <agentMint> [--executive <executive-wallet>]'
 
   static override args = {
-    asset: Args.string({ description: 'The agent asset address to revoke delegation for', required: true }),
+    agentMint: Args.string({ description: 'The agent\'s Core asset address', required: true }),
   }
 
   static override flags = {
@@ -41,7 +41,7 @@ export default class AgentsExecutiveRevoke extends TransactionCommand<typeof Age
     const { args, flags } = await this.parse(AgentsExecutiveRevoke)
     const { umi, explorer, chain, signer } = this.context
 
-    const assetPk = publicKey(args.asset)
+    const assetPk = publicKey(args.agentMint)
     const executivePk = flags.executive ? publicKey(flags.executive) : signer.publicKey
 
     // Derive PDAs
@@ -72,14 +72,14 @@ export default class AgentsExecutiveRevoke extends TransactionCommand<typeof Age
     const explorerUrl = generateExplorerUrl(explorer, chain, signature, 'transaction')
 
     this.log(`--------------------------------
-  Agent Asset: ${args.asset}
+  Agent Mint: ${args.agentMint}
   Executive Wallet: ${executivePk.toString()}
   Signature: ${signature}
   Explorer: ${explorerUrl}
 --------------------------------`)
 
     return {
-      agentAsset: args.asset,
+      agentMint: args.agentMint,
       executiveWallet: executivePk.toString(),
       signature,
       explorer: explorerUrl,

--- a/src/commands/agents/fetch.ts
+++ b/src/commands/agents/fetch.ts
@@ -14,18 +14,18 @@ export default class AgentsFetch extends BaseCommand<typeof AgentsFetch> {
   `
 
   static override examples = [
-    '<%= config.bin %> agents fetch <asset>',
+    '<%= config.bin %> agents fetch <agentMint>',
   ]
 
   static override args = {
-    asset: Args.string({ description: 'The MPL Core asset address to look up', required: true }),
+    agentMint: Args.string({ description: 'The agent\'s Core asset address', required: true }),
   }
 
   public async run(): Promise<unknown> {
     const { args } = await this.parse(AgentsFetch)
     const { umi } = this.context
 
-    const assetPk = publicKey(args.asset)
+    const assetPk = publicKey(args.agentMint)
 
     // Fetch the Core asset
     const asset = await fetchAssetV1(umi, assetPk)
@@ -36,7 +36,7 @@ export default class AgentsFetch extends BaseCommand<typeof AgentsFetch> {
 
     if (!identity) {
       this.log('No agent identity found for this asset. The asset may not be registered.')
-      return { registered: false, asset: args.asset }
+      return { registered: false, agentMint: args.agentMint }
     }
 
     // Derive the Asset Signer PDA (agent wallet)
@@ -47,10 +47,10 @@ export default class AgentsFetch extends BaseCommand<typeof AgentsFetch> {
 
     const result: Record<string, unknown> = {
       registered: true,
-      asset: args.asset,
+      agentMint: args.agentMint,
       owner: asset.owner.toString(),
       identityPda: identityPda.toString(),
-      wallet: walletPda.toString(),
+      agentWallet: walletPda.toString(),
       registrationUri: agentPlugin?.uri ?? null,
       lifecycleChecks: agentPlugin?.lifecycleChecks ?? null,
     }

--- a/src/commands/agents/fetch.ts
+++ b/src/commands/agents/fetch.ts
@@ -14,18 +14,18 @@ export default class AgentsFetch extends BaseCommand<typeof AgentsFetch> {
   `
 
   static override examples = [
-    '<%= config.bin %> agents fetch <agentMint>',
+    '<%= config.bin %> agents fetch <agentAsset>',
   ]
 
   static override args = {
-    agentMint: Args.string({ description: 'The agent\'s Core asset address', required: true }),
+    agentAsset: Args.string({ description: 'The agent\'s Core asset address', required: true }),
   }
 
   public async run(): Promise<unknown> {
     const { args } = await this.parse(AgentsFetch)
     const { umi } = this.context
 
-    const assetPk = publicKey(args.agentMint)
+    const assetPk = publicKey(args.agentAsset)
 
     // Fetch the Core asset
     const asset = await fetchAssetV1(umi, assetPk)
@@ -36,7 +36,7 @@ export default class AgentsFetch extends BaseCommand<typeof AgentsFetch> {
 
     if (!identity) {
       this.log('No agent identity found for this asset. The asset may not be registered.')
-      return { registered: false, agentMint: args.agentMint }
+      return { registered: false, agentAsset: args.agentAsset }
     }
 
     // Derive the Asset Signer PDA (agent wallet)
@@ -47,7 +47,7 @@ export default class AgentsFetch extends BaseCommand<typeof AgentsFetch> {
 
     const result: Record<string, unknown> = {
       registered: true,
-      agentMint: args.agentMint,
+      agentAsset: args.agentAsset,
       owner: asset.owner.toString(),
       identityPda: identityPda.toString(),
       agentWallet: walletPda.toString(),

--- a/src/commands/agents/register.ts
+++ b/src/commands/agents/register.ts
@@ -41,15 +41,15 @@ export default class AgentsRegister extends TransactionCommand<typeof AgentsRegi
   static override examples = [
     '$ mplx agents register --name "My Agent" --description "An AI agent" --image "./avatar.png"',
     '$ mplx agents register --name "My Agent" --description "An AI agent" --image "./avatar.png" --services \'[{"name":"MCP","endpoint":"https://myagent.com/mcp"}]\'',
-    '$ mplx agents register <asset> --use-ix --from-file "./agent-doc.json"',
+    '$ mplx agents register <agentMint> --use-ix --from-file "./agent-doc.json"',
     '$ mplx agents register --new --use-ix --name "My Agent" --description "An AI agent" --image "./avatar.png"',
     '$ mplx agents register --new --wizard',
   ]
 
-  static override usage = 'agents register [ASSET] [FLAGS]'
+  static override usage = 'agents register [AGENT_MINT] [FLAGS]'
 
   static override args = {
-    asset: Args.string({ description: 'The MPL Core asset address to register (not required with --new)', required: false }),
+    agentMint: Args.string({ description: 'The agent\'s Core asset address (not required with --new)', required: false }),
   }
 
   static override flags = {
@@ -206,7 +206,7 @@ export default class AgentsRegister extends TransactionCommand<typeof AgentsRegi
     const { umi, explorer, chain } = this.context
 
     // Determine asset address
-    if (flags.wizard && !flags.new && !args.asset) {
+    if (flags.wizard && !flags.new && !args.agentMint) {
       const assetMode = await select({
         message: 'Register a new asset or an existing one?',
         choices: [
@@ -218,9 +218,9 @@ export default class AgentsRegister extends TransactionCommand<typeof AgentsRegi
       if (assetMode === 'new') {
         flags.new = true
       } else {
-        args.asset = await input({
-          message: 'Existing Asset Address?',
-          validate: (value: string) => value ? true : 'Asset address is required',
+        args.agentMint = await input({
+          message: 'Existing Agent Mint Address?',
+          validate: (value: string) => value ? true : 'Agent mint address is required',
         })
       }
     }
@@ -231,10 +231,10 @@ export default class AgentsRegister extends TransactionCommand<typeof AgentsRegi
     if (flags.new) {
       assetAddress = assetSigner!.publicKey.toString()
     } else {
-      if (!args.asset) {
-        this.error('Asset address is required. Provide an asset address or use --new to create one.')
+      if (!args.agentMint) {
+        this.error('Agent mint address is required. Provide an agentMint address or use --new to create one.')
       }
-      assetAddress = args.asset
+      assetAddress = args.agentMint
     }
 
     const { uri, document } = await this.resolveDocumentUri(flags, assetAddress)
@@ -276,14 +276,14 @@ export default class AgentsRegister extends TransactionCommand<typeof AgentsRegi
     const explorerUrl = generateExplorerUrl(explorer, chain, signature, 'transaction')
 
     this.log(`--------------------------------
-  Asset: ${assetAddress}
+  Agent Mint: ${assetAddress}
   Registration URI: ${uri}
   Signature: ${signature}
   Explorer: ${explorerUrl}
 --------------------------------`)
 
     return {
-      asset: assetAddress,
+      agentMint: assetAddress,
       registrationUri: uri,
       collection: flags.collection ?? null,
       signature,
@@ -357,13 +357,13 @@ export default class AgentsRegister extends TransactionCommand<typeof AgentsRegi
       const explorerUrl = generateExplorerUrl(explorer, chain, signature, 'transaction')
 
       this.log(`--------------------------------
-  Asset: ${result.assetAddress}
+  Agent Mint: ${result.assetAddress}
   Signature: ${signature}
   Explorer: ${explorerUrl}
 --------------------------------`)
 
       return {
-        asset: result.assetAddress,
+        agentMint: result.assetAddress,
         signature,
         explorer: explorerUrl,
       }
@@ -387,7 +387,7 @@ export default class AgentsRegister extends TransactionCommand<typeof AgentsRegi
     const { args, flags } = await this.parse(AgentsRegister)
 
     // These workflows require the direct IX path
-    const useIx = flags['use-ix'] || flags.wizard || flags['from-file'] || args.asset
+    const useIx = flags['use-ix'] || flags.wizard || flags['from-file'] || args.agentMint
       || flags.owner || flags.collection
 
     if (useIx) {

--- a/src/commands/agents/register.ts
+++ b/src/commands/agents/register.ts
@@ -41,15 +41,15 @@ export default class AgentsRegister extends TransactionCommand<typeof AgentsRegi
   static override examples = [
     '$ mplx agents register --name "My Agent" --description "An AI agent" --image "./avatar.png"',
     '$ mplx agents register --name "My Agent" --description "An AI agent" --image "./avatar.png" --services \'[{"name":"MCP","endpoint":"https://myagent.com/mcp"}]\'',
-    '$ mplx agents register <agentMint> --use-ix --from-file "./agent-doc.json"',
+    '$ mplx agents register <agentAsset> --use-ix --from-file "./agent-doc.json"',
     '$ mplx agents register --new --use-ix --name "My Agent" --description "An AI agent" --image "./avatar.png"',
     '$ mplx agents register --new --wizard',
   ]
 
-  static override usage = 'agents register [AGENT_MINT] [FLAGS]'
+  static override usage = 'agents register [AGENT_ASSET] [FLAGS]'
 
   static override args = {
-    agentMint: Args.string({ description: 'The agent\'s Core asset address (not required with --new)', required: false }),
+    agentAsset: Args.string({ description: 'The agent\'s Core asset address (not required with --new)', required: false }),
   }
 
   static override flags = {
@@ -206,7 +206,7 @@ export default class AgentsRegister extends TransactionCommand<typeof AgentsRegi
     const { umi, explorer, chain } = this.context
 
     // Determine asset address
-    if (flags.wizard && !flags.new && !args.agentMint) {
+    if (flags.wizard && !flags.new && !args.agentAsset) {
       const assetMode = await select({
         message: 'Register a new asset or an existing one?',
         choices: [
@@ -218,9 +218,9 @@ export default class AgentsRegister extends TransactionCommand<typeof AgentsRegi
       if (assetMode === 'new') {
         flags.new = true
       } else {
-        args.agentMint = await input({
-          message: 'Existing Agent Mint Address?',
-          validate: (value: string) => value ? true : 'Agent mint address is required',
+        args.agentAsset = await input({
+          message: 'Existing Agent Asset Address?',
+          validate: (value: string) => value ? true : 'Agent asset address is required',
         })
       }
     }
@@ -231,10 +231,10 @@ export default class AgentsRegister extends TransactionCommand<typeof AgentsRegi
     if (flags.new) {
       assetAddress = assetSigner!.publicKey.toString()
     } else {
-      if (!args.agentMint) {
-        this.error('Agent mint address is required. Provide an agentMint address or use --new to create one.')
+      if (!args.agentAsset) {
+        this.error('Agent asset address is required. Provide an agentAsset address or use --new to create one.')
       }
-      assetAddress = args.agentMint
+      assetAddress = args.agentAsset
     }
 
     const { uri, document } = await this.resolveDocumentUri(flags, assetAddress)
@@ -276,14 +276,14 @@ export default class AgentsRegister extends TransactionCommand<typeof AgentsRegi
     const explorerUrl = generateExplorerUrl(explorer, chain, signature, 'transaction')
 
     this.log(`--------------------------------
-  Agent Mint: ${assetAddress}
+  Agent Asset: ${assetAddress}
   Registration URI: ${uri}
   Signature: ${signature}
   Explorer: ${explorerUrl}
 --------------------------------`)
 
     return {
-      agentMint: assetAddress,
+      agentAsset: assetAddress,
       registrationUri: uri,
       collection: flags.collection ?? null,
       signature,
@@ -357,13 +357,13 @@ export default class AgentsRegister extends TransactionCommand<typeof AgentsRegi
       const explorerUrl = generateExplorerUrl(explorer, chain, signature, 'transaction')
 
       this.log(`--------------------------------
-  Agent Mint: ${result.assetAddress}
+  Agent Asset: ${result.assetAddress}
   Signature: ${signature}
   Explorer: ${explorerUrl}
 --------------------------------`)
 
       return {
-        agentMint: result.assetAddress,
+        agentAsset: result.assetAddress,
         signature,
         explorer: explorerUrl,
       }
@@ -387,7 +387,7 @@ export default class AgentsRegister extends TransactionCommand<typeof AgentsRegi
     const { args, flags } = await this.parse(AgentsRegister)
 
     // These workflows require the direct IX path
-    const useIx = flags['use-ix'] || flags.wizard || flags['from-file'] || args.agentMint
+    const useIx = flags['use-ix'] || flags.wizard || flags['from-file'] || args.agentAsset
       || flags.owner || flags.collection
 
     if (useIx) {

--- a/src/commands/agents/set-agent-token.ts
+++ b/src/commands/agents/set-agent-token.ts
@@ -23,13 +23,13 @@ export default class AgentsSetAgentToken extends TransactionCommand<typeof Agent
   `
 
   static override examples = [
-    '$ mplx agents set-agent-token <agentMint> <genesis-account>',
+    '$ mplx agents set-agent-token <agentAsset> <genesis-account>',
   ]
 
-  static override usage = 'agents set-agent-token <agentMint> <genesis-account>'
+  static override usage = 'agents set-agent-token <agentAsset> <genesis-account>'
 
   static override args = {
-    agentMint: Args.string({ description: 'The agent\'s Core asset address', required: true }),
+    agentAsset: Args.string({ description: 'The agent\'s Core asset address', required: true }),
     genesis: Args.string({ description: 'The Genesis account address for the token launch', required: true }),
   }
 
@@ -37,7 +37,7 @@ export default class AgentsSetAgentToken extends TransactionCommand<typeof Agent
     const { args } = await this.parse(AgentsSetAgentToken)
     const { umi, explorer, chain } = this.context
 
-    const assetPk = publicKey(args.agentMint)
+    const assetPk = publicKey(args.agentAsset)
     const genesisPk = publicKey(args.genesis)
 
     const spinner = ora('Setting agent token...').start()
@@ -60,14 +60,14 @@ export default class AgentsSetAgentToken extends TransactionCommand<typeof Agent
     const explorerUrl = generateExplorerUrl(explorer, chain, signature, 'transaction')
 
     this.log(`--------------------------------
-  Agent Mint: ${args.agentMint}
+  Agent Asset: ${args.agentAsset}
   Genesis Account: ${args.genesis}
   Signature: ${signature}
   Explorer: ${explorerUrl}
 --------------------------------`)
 
     return {
-      agentMint: args.agentMint,
+      agentAsset: args.agentAsset,
       genesisAccount: args.genesis,
       signature,
       explorer: explorerUrl,

--- a/src/commands/agents/set-agent-token.ts
+++ b/src/commands/agents/set-agent-token.ts
@@ -23,13 +23,13 @@ export default class AgentsSetAgentToken extends TransactionCommand<typeof Agent
   `
 
   static override examples = [
-    '$ mplx agents set-agent-token <agent-asset> <genesis-account>',
+    '$ mplx agents set-agent-token <agentMint> <genesis-account>',
   ]
 
-  static override usage = 'agents set-agent-token <agent-asset> <genesis-account>'
+  static override usage = 'agents set-agent-token <agentMint> <genesis-account>'
 
   static override args = {
-    asset: Args.string({ description: 'The registered agent asset address', required: true }),
+    agentMint: Args.string({ description: 'The agent\'s Core asset address', required: true }),
     genesis: Args.string({ description: 'The Genesis account address for the token launch', required: true }),
   }
 
@@ -37,7 +37,7 @@ export default class AgentsSetAgentToken extends TransactionCommand<typeof Agent
     const { args } = await this.parse(AgentsSetAgentToken)
     const { umi, explorer, chain } = this.context
 
-    const assetPk = publicKey(args.asset)
+    const assetPk = publicKey(args.agentMint)
     const genesisPk = publicKey(args.genesis)
 
     const spinner = ora('Setting agent token...').start()
@@ -60,14 +60,14 @@ export default class AgentsSetAgentToken extends TransactionCommand<typeof Agent
     const explorerUrl = generateExplorerUrl(explorer, chain, signature, 'transaction')
 
     this.log(`--------------------------------
-  Agent Asset: ${args.asset}
+  Agent Mint: ${args.agentMint}
   Genesis Account: ${args.genesis}
   Signature: ${signature}
   Explorer: ${explorerUrl}
 --------------------------------`)
 
     return {
-      agentAsset: args.asset,
+      agentMint: args.agentMint,
       genesisAccount: args.genesis,
       signature,
       explorer: explorerUrl,

--- a/src/commands/config/wallets/add.ts
+++ b/src/commands/config/wallets/add.ts
@@ -27,7 +27,7 @@ export default class ConfigWalletAddCommand extends Command {
       description: 'Core asset address to create an asset-signer wallet from',
     }),
     agent: Flags.string({
-      description: 'Agent mint address (Core asset) to create an agent wallet from',
+      description: 'Agent Core asset address to create an agent wallet from',
     }),
   }
 
@@ -35,7 +35,7 @@ export default class ConfigWalletAddCommand extends Command {
     '<%= config.bin %> <%= command.id %> my-wallet ~/.config/solana/id.json',
     '<%= config.bin %> <%= command.id %> mainnet-wallet ./wallets/mainnet.json',
     '<%= config.bin %> <%= command.id %> vault --asset <assetId>',
-    '<%= config.bin %> <%= command.id %> my-agent --agent <agentMint>',
+    '<%= config.bin %> <%= command.id %> my-agent --agent <agentAsset>',
   ]
 
   public async run(): Promise<unknown> {
@@ -62,13 +62,13 @@ export default class ConfigWalletAddCommand extends Command {
     let wallet: WalletEntry
 
     if (flags.agent) {
-      // Agent wallet — derives the signer PDA from the agent's Core asset mint
-      const agentMintPubkey = publicKey(flags.agent)
-      const [pdaPubkey] = findAssetSignerPda(DUMMY_UMI, { asset: agentMintPubkey })
+      // Agent wallet — derives the signer PDA from the agent's Core asset address
+      const agentAssetPubkey = publicKey(flags.agent)
+      const [pdaPubkey] = findAssetSignerPda(DUMMY_UMI, { asset: agentAssetPubkey })
 
       const mergedConfig = consolidateConfigs(DEFAULT_CONFIG, config, { rpcUrl: flags.rpc })
       const umi = createUmi(mergedConfig.rpcUrl!).use(mplCore())
-      const asset = await fetchAsset(umi, agentMintPubkey).catch(() => {
+      const asset = await fetchAsset(umi, agentAssetPubkey).catch(() => {
         this.error(`Could not fetch agent asset ${flags.agent}. Make sure it exists and your RPC is reachable.`)
       })
 
@@ -106,7 +106,7 @@ export default class ConfigWalletAddCommand extends Command {
 
       this.log(
         `✅ Agent wallet '${args.name}' added!\n` +
-        `   Agent Mint:   ${flags.agent}\n` +
+        `   Agent Asset:   ${flags.agent}\n` +
         `   Agent Wallet: ${pdaPubkey.toString()}\n` +
         `   Owner:        ${ownerWallet.name} (${shortenAddress(ownerAddress)})\n` +
         `\nUse 'mplx config wallets set ${args.name}' to make this your active wallet.`
@@ -115,7 +115,7 @@ export default class ConfigWalletAddCommand extends Command {
       return {
         name: args.name,
         type: 'agent',
-        agentMint: flags.agent,
+        agentAsset: flags.agent,
         agentWallet: pdaPubkey.toString(),
         owner: ownerWallet.name,
       }

--- a/src/commands/config/wallets/add.ts
+++ b/src/commands/config/wallets/add.ts
@@ -12,19 +12,22 @@ import { shortenAddress, DUMMY_UMI } from '../../../lib/util.js'
 export default class ConfigWalletAddCommand extends Command {
   static enableJsonFlag = true
 
-  static override description = 'Add a new wallet to your configuration. Use --asset to add an asset-signer wallet.'
+  static override description = 'Add a new wallet to your configuration. Use --asset for a generic Core asset-signer wallet, or --agent for an agent wallet.'
 
   static override args = {
     name: Args.string({
       description: 'Name of wallet (alphanumeric, hyphens and underscores only)',
       required: true,
     }),
-    path: Args.string({ description: 'Path to keypair json file (not required for --asset)', required: false }),
+    path: Args.string({ description: 'Path to keypair json file (not required for --asset or --agent)', required: false }),
   }
 
   static override flags = {
     asset: Flags.string({
-      description: 'Asset ID to create an asset-signer wallet from',
+      description: 'Core asset address to create an asset-signer wallet from',
+    }),
+    agent: Flags.string({
+      description: 'Agent mint address (Core asset) to create an agent wallet from',
     }),
   }
 
@@ -32,6 +35,7 @@ export default class ConfigWalletAddCommand extends Command {
     '<%= config.bin %> <%= command.id %> my-wallet ~/.config/solana/id.json',
     '<%= config.bin %> <%= command.id %> mainnet-wallet ./wallets/mainnet.json',
     '<%= config.bin %> <%= command.id %> vault --asset <assetId>',
+    '<%= config.bin %> <%= command.id %> my-agent --agent <agentMint>',
   ]
 
   public async run(): Promise<unknown> {
@@ -56,6 +60,66 @@ export default class ConfigWalletAddCommand extends Command {
     }
 
     let wallet: WalletEntry
+
+    if (flags.agent) {
+      // Agent wallet — derives the signer PDA from the agent's Core asset mint
+      const agentMintPubkey = publicKey(flags.agent)
+      const [pdaPubkey] = findAssetSignerPda(DUMMY_UMI, { asset: agentMintPubkey })
+
+      const mergedConfig = consolidateConfigs(DEFAULT_CONFIG, config, { rpcUrl: flags.rpc })
+      const umi = createUmi(mergedConfig.rpcUrl!).use(mplCore())
+      const asset = await fetchAsset(umi, agentMintPubkey).catch(() => {
+        this.error(`Could not fetch agent asset ${flags.agent}. Make sure it exists and your RPC is reachable.`)
+      })
+
+      const ownerAddress = asset.owner.toString()
+
+      const ownerWallet = config.wallets.find(
+        w => w.address === ownerAddress && w.type !== 'asset-signer' && w.type !== 'agent'
+      )
+
+      if (!ownerWallet) {
+        this.error(
+          `Agent owner ${shortenAddress(ownerAddress)} is not in your saved wallets.\n` +
+          `Add the owner wallet first: mplx config wallets add <name> <keypair-path>`
+        )
+      }
+
+      const existingAddress = config.wallets.find((w) => w.address === pdaPubkey.toString())
+      if (existingAddress) {
+        this.error(`This agent's wallet PDA (${shortenAddress(pdaPubkey)}) is already configured as '${existingAddress.name}'.`)
+      }
+
+      wallet = {
+        name: args.name,
+        type: 'agent',
+        asset: flags.agent,
+        address: pdaPubkey.toString(),
+        payer: ownerWallet.name,
+      }
+
+      config.wallets.push(wallet)
+
+      const dir = dirname(configPath)
+      ensureDirectoryExists(dir)
+      writeJsonSync(configPath, config)
+
+      this.log(
+        `✅ Agent wallet '${args.name}' added!\n` +
+        `   Agent Mint:   ${flags.agent}\n` +
+        `   Agent Wallet: ${pdaPubkey.toString()}\n` +
+        `   Owner:        ${ownerWallet.name} (${shortenAddress(ownerAddress)})\n` +
+        `\nUse 'mplx config wallets set ${args.name}' to make this your active wallet.`
+      )
+
+      return {
+        name: args.name,
+        type: 'agent',
+        agentMint: flags.agent,
+        agentWallet: pdaPubkey.toString(),
+        owner: ownerWallet.name,
+      }
+    }
 
     if (flags.asset) {
       // Asset-signer wallet

--- a/src/commands/genesis/launch/create.ts
+++ b/src/commands/genesis/launch/create.ts
@@ -586,6 +586,9 @@ Use --wizard for an interactive guided setup.`
         launchId: result.launch.id,
         launchLink: result.launch.link,
         mintAddress: result.mintAddress,
+        ...(launchInput.agent && {
+          agentMint: typeof launchInput.agent.mint === 'string' ? launchInput.agent.mint : launchInput.agent.mint.toString(),
+        }),
         signatures: result.signatures.map((sig: Uint8Array) => {
           const sigStr = txSignatureToString(sig)
           return { explorer: generateExplorerUrl(this.context.explorer, this.context.chain, sigStr, 'transaction'), signature: sigStr }

--- a/src/commands/genesis/launch/create.ts
+++ b/src/commands/genesis/launch/create.ts
@@ -215,7 +215,7 @@ Supports two launch types:
   - launchpool: Project-style launch with deposit period, raise goal, and Raydium LP
   - bonding-curve: Instant bonding curve launch with optional first buy and creator fees
 
-Agent mode (--agentMint) wraps transactions for execution by an on-chain agent,
+Agent mode (--agentAsset) wraps transactions for execution by an on-chain agent,
 enabling AI agents to launch tokens autonomously.
 
 Use --wizard for an interactive guided setup.`
@@ -225,20 +225,20 @@ Use --wizard for an interactive guided setup.`
     '$ mplx genesis launch create --name "My Token" --symbol "MTK" --image "https://gateway.irys.xyz/abc123" --tokenAllocation 500000000 --depositStartTime 2025-03-01T00:00:00Z --raiseGoal 200 --raydiumLiquidityBps 5000 --fundsRecipient <ADDRESS>',
     '$ mplx genesis launch create --launchType bonding-curve --name "My Meme" --symbol "MEME" --image "https://gateway.irys.xyz/abc123"',
     '$ mplx genesis launch create --launchType bonding-curve --name "My Meme" --symbol "MEME" --image "https://gateway.irys.xyz/abc123" --creatorFeeWallet <ADDRESS> --firstBuyAmount 0.1',
-    '$ mplx genesis launch create --launchType bonding-curve --name "Agent Token" --symbol "AGT" --image "https://gateway.irys.xyz/abc123" --agentMint <AGENT_NFT_ADDRESS> --agentSetToken',
+    '$ mplx genesis launch create --launchType bonding-curve --name "Agent Token" --symbol "AGT" --image "https://gateway.irys.xyz/abc123" --agentAsset <AGENT_NFT_ADDRESS> --agentSetToken',
     '$ mplx genesis launch create --name "My Token" --symbol "MTK" --image "https://gateway.irys.xyz/abc123" --tokenAllocation 500000000 --depositStartTime 2025-03-01T00:00:00Z --raiseGoal 200 --raydiumLiquidityBps 5000 --fundsRecipient <ADDRESS> --lockedAllocations allocations.json',
   ]
 
   static override flags = {
     // Agent mode
-    agentMint: Flags.string({
-      description: 'Agent NFT mint address. Wraps transactions for agent execution, enabling AI agents to launch tokens.',
+    agentAsset: Flags.string({
+      description: 'Agent Core asset address. Wraps transactions for agent execution, enabling AI agents to launch tokens.',
       required: false,
     }),
 
     agentSetToken: Flags.boolean({
       default: false,
-      description: 'When using --agentMint, set the launched token on the agent NFT.',
+      description: 'When using --agentAsset, set the launched token on the agent NFT.',
     }),
 
     apiUrl: Flags.string({
@@ -415,12 +415,12 @@ Use --wizard for an interactive guided setup.`
     }
 
     // Validate agent flags
-    if (flags.agentMint && !isPublicKey(flags.agentMint)) {
-      this.error('--agentMint must be a valid public key (agent NFT mint address)')
+    if (flags.agentAsset && !isPublicKey(flags.agentAsset)) {
+      this.error('--agentAsset must be a valid public key (agent Core asset address)')
     }
 
-    if (flags.agentSetToken && !flags.agentMint) {
-      this.error('--agentSetToken requires --agentMint')
+    if (flags.agentSetToken && !flags.agentAsset) {
+      this.error('--agentSetToken requires --agentAsset')
     }
 
     // Detect network from chain if not specified
@@ -449,9 +449,9 @@ Use --wizard for an interactive guided setup.`
       },
       wallet: this.context.umi.identity.publicKey.toString(),
       ...(flags.quoteMint !== 'SOL' && { quoteMint: flags.quoteMint as QuoteMintInput }),
-      ...(flags.agentMint && {
+      ...(flags.agentAsset && {
         agent: {
-          mint: flags.agentMint,
+          mint: flags.agentAsset,
           setToken: flags.agentSetToken,
         },
       }),
@@ -489,8 +489,8 @@ Use --wizard for an interactive guided setup.`
       this.context.umi.identity.publicKey.toString(),
       this.context.chain,
       {
-        agent: wizardResult.agentMint ? {
-          mint: wizardResult.agentMint,
+        agent: wizardResult.agentAsset ? {
+          mint: wizardResult.agentAsset,
           setToken: wizardResult.agentSetToken ?? false,
         } : undefined,
         creatorFeeWallet: wizardResult.creatorFeeWallet,
@@ -560,7 +560,7 @@ Use --wizard for an interactive guided setup.`
       this.log(`Launch Link: ${result.launch.link}`)
       this.log(`Token ID: ${result.token.id}`)
       if (launchInput.agent) {
-        this.log(`Agent Mint: ${typeof launchInput.agent.mint === 'string' ? launchInput.agent.mint : launchInput.agent.mint.toString()}`)
+        this.log(`Agent Asset: ${typeof launchInput.agent.mint === 'string' ? launchInput.agent.mint : launchInput.agent.mint.toString()}`)
       }
 
       this.log('')
@@ -587,7 +587,7 @@ Use --wizard for an interactive guided setup.`
         launchLink: result.launch.link,
         mintAddress: result.mintAddress,
         ...(launchInput.agent && {
-          agentMint: typeof launchInput.agent.mint === 'string' ? launchInput.agent.mint : launchInput.agent.mint.toString(),
+          agentAsset: typeof launchInput.agent.mint === 'string' ? launchInput.agent.mint : launchInput.agent.mint.toString(),
         }),
         signatures: result.signatures.map((sig: Uint8Array) => {
           const sigStr = txSignatureToString(sig)

--- a/src/lib/Context.ts
+++ b/src/lib/Context.ts
@@ -36,6 +36,7 @@ export type WalletEntry = {
 } & (
   | { type?: 'file'; path: string }
   | { type: 'asset-signer'; asset: string; payer?: string }
+  | { type: 'agent'; asset: string; payer?: string }
 )
 
 export type ConfigJson = {
@@ -170,7 +171,7 @@ export const createContext = async (configPath: string, overrides: ConfigJson, i
   // Check if the active wallet is an asset-signer.
   // An explicit --keypair flag overrides the asset-signer wallet.
   const activeWallet = overrides.keypair ? undefined : resolveActiveWallet(config)
-  const isAssetSigner = activeWallet?.type === 'asset-signer'
+  const isAssetSigner = activeWallet?.type === 'asset-signer' || activeWallet?.type === 'agent'
 
   let signer: Signer
   let assetSigner: AssetSignerInfo | undefined
@@ -190,7 +191,7 @@ export const createContext = async (configPath: string, overrides: ConfigJson, i
     const walletPayerName = activeWallet.payer
     if (walletPayerName && config.wallets) {
       const ownerWallet = config.wallets.find(w => w.name === walletPayerName)
-      if (ownerWallet && ownerWallet.type !== 'asset-signer' && 'path' in ownerWallet) {
+      if (ownerWallet && ownerWallet.type !== 'asset-signer' && ownerWallet.type !== 'agent' && 'path' in ownerWallet) {
         ownerPath = ownerWallet.path
       }
     }

--- a/src/lib/genesis/createGenesisWizardPrompt.ts
+++ b/src/lib/genesis/createGenesisWizardPrompt.ts
@@ -44,7 +44,7 @@ export interface LaunchWizardResult {
   creatorFeeWallet?: string
   firstBuyAmount?: number
   // agent support
-  agentMint?: string
+  agentAsset?: string
   agentSetToken?: boolean
 }
 
@@ -306,7 +306,7 @@ export async function promptProjectConfig(quoteMint: string): Promise<{
 /*  Agent prompts                                                      */
 /* ------------------------------------------------------------------ */
 
-export async function promptAgentConfig(): Promise<{ agentMint?: string; agentSetToken?: boolean }> {
+export async function promptAgentConfig(): Promise<{ agentAsset?: string; agentSetToken?: boolean }> {
   const useAgent = await confirm({
     message: 'Launch as an agent? (wraps transactions for on-chain agent execution)',
     default: false,
@@ -314,14 +314,14 @@ export async function promptAgentConfig(): Promise<{ agentMint?: string; agentSe
 
   if (!useAgent) return {}
 
-  const agentMint = await promptPublicKeyInput('Agent NFT mint address:')
+  const agentAsset = await promptPublicKeyInput('Agent Core asset address:')
 
   const agentSetToken = await confirm({
     message: 'Set the launched token on the agent NFT?',
     default: true,
   })
 
-  return { agentMint, agentSetToken }
+  return { agentAsset, agentSetToken }
 }
 
 /* ------------------------------------------------------------------ */
@@ -646,8 +646,8 @@ export async function promptLaunchWizard(): Promise<LaunchWizardResult> {
     if (firstBuyAmount) console.log(`  First Buy Amount: ${firstBuyAmount} SOL`)
     if (!creatorFeeWallet && !firstBuyAmount) console.log('  Using default bonding curve settings')
   }
-  if (agentConfig.agentMint) {
-    console.log(`  Agent Mint: ${agentConfig.agentMint}`)
+  if (agentConfig.agentAsset) {
+    console.log(`  Agent Asset: ${agentConfig.agentAsset}`)
     console.log(`  Set Token on Agent: ${agentConfig.agentSetToken ? 'Yes' : 'No'}`)
   }
   console.log('')
@@ -671,7 +671,7 @@ export async function promptLaunchWizard(): Promise<LaunchWizardResult> {
     ...(fundsRecipient && { fundsRecipient }),
     ...(creatorFeeWallet && { creatorFeeWallet }),
     ...(firstBuyAmount !== undefined && { firstBuyAmount }),
-    ...(agentConfig.agentMint && { agentMint: agentConfig.agentMint }),
+    ...(agentConfig.agentAsset && { agentAsset: agentConfig.agentAsset }),
     ...(agentConfig.agentSetToken !== undefined && { agentSetToken: agentConfig.agentSetToken }),
   }
 }

--- a/src/lib/genesis/launchApi.ts
+++ b/src/lib/genesis/launchApi.ts
@@ -13,7 +13,7 @@ import { detectSvmNetwork, RpcChain } from '../util.js'
 /* ------------------------------------------------------------------ */
 
 export interface AgentConfig {
-  /** Agent NFT mint address */
+  /** Agent Core asset address */
   mint: PublicKeyInput
   /** Whether to set the token on the agent */
   setToken: boolean

--- a/src/lib/genesis/wizard.ts
+++ b/src/lib/genesis/wizard.ts
@@ -108,8 +108,8 @@ export async function runApiWizard(
       fundsRecipient: wizardResult.fundsRecipient,
       creatorFeeWallet: wizardResult.creatorFeeWallet,
       firstBuyAmount: wizardResult.firstBuyAmount,
-      agent: wizardResult.agentMint ? {
-        mint: wizardResult.agentMint,
+      agent: wizardResult.agentAsset ? {
+        mint: wizardResult.agentAsset,
         setToken: wizardResult.agentSetToken ?? false,
       } : undefined,
     },

--- a/test/commands/genesis/genesis.launch.test.ts
+++ b/test/commands/genesis/genesis.launch.test.ts
@@ -293,7 +293,7 @@ describe('genesis launch commands', () => {
                 '--name', 'Agent Token',
                 '--symbol', 'AGT',
                 '--image', 'https://gateway.irys.xyz/abc123',
-                '--agentMint', 'TESTfCYwTPxME2cAnPcKvvF5xdPah3PY7naYQEP2kkx',
+                '--agentAsset', 'TESTfCYwTPxME2cAnPcKvvF5xdPah3PY7naYQEP2kkx',
                 '--agentSetToken',
             ]
 
@@ -346,7 +346,7 @@ describe('genesis launch commands', () => {
             }
         })
 
-        it('rejects --agentSetToken without --agentMint', async () => {
+        it('rejects --agentSetToken without --agentAsset', async () => {
             const cliInput = [
                 'genesis', 'launch', 'create',
                 '--name', 'My Token',
@@ -362,10 +362,10 @@ describe('genesis launch commands', () => {
 
             try {
                 await runCli(cliInput)
-                expect.fail('Should have thrown an error for agentSetToken without agentMint')
+                expect.fail('Should have thrown an error for agentSetToken without agentAsset')
             } catch (error) {
                 const msg = (error as Error).message
-                expect(msg).to.contain('--agentSetToken requires --agentMint')
+                expect(msg).to.contain('--agentSetToken requires --agentAsset')
             }
         })
     })


### PR DESCRIPTION
## Summary                                                                                                                                                   
  
  Aligns all agent command inputs and outputs with the canonical names agreed by the team: **`agentAsset`** for the Core asset address (on-chain identity) and   **`agentWallet`** for the Asset Signer PDA (operational wallet).                                                                                             
                                                                                                                                                               
  Previously these concepts had inconsistent names across commands — `asset`, `agentMint`, `wallet`, `signerPda` were all used interchangeably. This PR makes
  them uniform.

  ## Changes

  | Command | What changed |
  |---|---|
  | `agents fetch` | arg + output: `asset` → `agentAsset`, `wallet` → `agentWallet` |
  | `agents register` | arg + output: `asset` → `agentAsset` (both API and on-chain paths) |
  | `agents set-agent-token` | arg + output: `asset` / `agentMint` → `agentAsset` |
  | `agents executive delegate` | arg + output: `asset` / `agentMint` → `agentAsset` |
  | `agents executive revoke` | arg + output: `asset` / `agentMint` → `agentAsset` |
  | `genesis launch create` | `agentAsset` now included in JSON output when agent mode is active |
  | `config wallets add` | new `--agent <agentAsset>` flag; outputs `agentAsset` / `agentWallet` / `type: 'agent'`; existing `--asset` path unchanged |        
  | `Context.ts` | `type: 'agent'` added to `WalletEntry` union, treated identically to `asset-signer` at runtime |

  ## Notes

  - `core asset execute info` is intentionally unchanged — it is a generic Core asset command, not agent-specific, so `asset` / `signerPda` remain appropriate 
  there.
  - `config wallets add --asset` is also unchanged. The new `--agent` flag is an agent-specific path that uses the new naming; the generic asset-signer path   
  keeps its existing field names.
  - No breaking changes to runtime behaviour — only naming of CLI args and JSON output fields.