### PR TITLE
Add metaplex as a longform bin alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.4.1",
   "author": "Metaplex <contact@metaplex.com>",
   "bin": {
-    "mplx": "./bin/run.js"
+    "mplx": "./bin/run.js",
+    "metaplex": "./bin/run.js"
   },
   "oclif": {
     "commands": "./dist/commands",
@@ -106,6 +107,7 @@
     "build:clean": "pnpm run clean && pnpm run build",
     "dev": "./bin/dev.js",
     "mplx": "./bin/run.js",
+    "metaplex": "./bin/run.js",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext .ts",
     "lint:fix": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext .ts --fix",
     "postpack": "shx rm -f oclif.manifest.json",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metaplex-foundation/cli",
   "description": "Metaplex CLI",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": "Metaplex <contact@metaplex.com>",
   "bin": {
     "mplx": "./bin/run.js",


### PR DESCRIPTION
## Summary
- Adds `metaplex` as a second bin alias pointing to the same entry point as `mplx`
- Improves discoverability, particularly for AI assistants that check for the CLI by searching for `metaplex` rather than the short-form `mplx`

## Test plan
- [ ] Install the package globally and verify both `mplx` and `metaplex` resolve to the same CLI
- [ ] Confirm `metaplex --version` and `metaplex --help` work as expected